### PR TITLE
Clean up vroom files to introduce concepts better, add autopep8 coverage

### DIFF
--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -184,13 +184,13 @@ if !exists('s:autopep8')
           \ maktaba#syscall#Create([l:executable, '--version']).Call()
       " In some cases version is written to stderr, in some to stdout
       let l:version_output = empty(version_call.stderr) ?
-            \ version_call.stdout : version_call.stderr
+          \ version_call.stdout : version_call.stderr
       let l:autopep8_version =
           \ matchlist(l:version_output, '\m\Cautopep8 \(\d\+\)\.')
       if empty(l:autopep8_version)
         throw maktaba#error#Failure(
-              \ 'Unable to parse version from `%s --version`: %s',
-              \ l:executable, l:version_output)
+            \ 'Unable to parse version from `%s --version`: %s',
+            \ l:executable, l:version_output)
       else
         let s:autopep8_supports_range = l:autopep8_version[1] >= 1
       endif
@@ -289,7 +289,7 @@ function! s:GetFormatter(...) abort
     if !empty(l:default_formatters)
       let l:formatter = l:default_formatters[0]
     else
-      " Check if we have formatters that are not avialable for some reason.
+      " Check if we have formatters that are not available for some reason.
       " Report a better error message in that case.
       let l:unavailable_formatters = filter(
             \ copy(l:formatters), 'v:val.AppliesToBuffer()')
@@ -392,4 +392,22 @@ endfunction
 " to avoid checking for executables on the path.
 function! codefmt#DisableIsAvailableChecksForTesting() abort
   let s:check_formatters_available = 0
+endfunction
+
+
+""
+" @private
+" Undoes the effect of @function(#DisableIsAvailableChecksForTesting), allowing
+" FORMATTER.IsAvailable checks to work normally.
+function! codefmt#DontDisableIsAvailableChecksForTesting() abort
+  let s:check_formatters_available = 1
+endfunction
+
+
+""
+" @private
+" Invalidates the cached autopep8 version detection for testing, forcing the
+" autopep8 formatter to check for it again on the next invocation.
+function! codefmt#ForgetAutopep8VersionForTesting() abort
+  unlet! s:autopep8_supports_range
 endfunction

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -230,8 +230,9 @@ endif
 
 ""
 " Checks whether {formatter} is available.
-" NOTE: If @function(#DisableIsAvailableChecksForTesting) has been called, skips
-" the IsAvailable check and always returns true.
+" NOTE: If IsAvailable checks are disabled via
+" @function(#SetWhetherToPerformIsAvailableChecksForTesting), skips the
+" IsAvailable check and always returns true.
 function! s:IsAvailable(formatter) abort
   if get(s:, 'check_formatters_available', 1)
     return a:formatter.IsAvailable()
@@ -388,26 +389,19 @@ endfunction
 
 ""
 " @private
-" Bypasses FORMATTER.IsAvailable checks and assumes every formatter is available
-" to avoid checking for executables on the path.
-function! codefmt#DisableIsAvailableChecksForTesting() abort
-  let s:check_formatters_available = 0
-endfunction
-
-
-""
-" @private
-" Undoes the effect of @function(#DisableIsAvailableChecksForTesting), allowing
-" FORMATTER.IsAvailable checks to work normally.
-function! codefmt#DontDisableIsAvailableChecksForTesting() abort
-  let s:check_formatters_available = 1
-endfunction
-
-
-""
-" @private
 " Invalidates the cached autopep8 version detection for testing, forcing the
 " autopep8 formatter to check for it again on the next invocation.
-function! codefmt#ForgetAutopep8VersionForTesting() abort
+function! codefmt#InvalidateAutopep8Version() abort
   unlet! s:autopep8_supports_range
+endfunction
+
+
+""
+" @private
+" Configures whether codefmt should bypass FORMATTER.IsAvailable checks and
+" assume every formatter is available to avoid checking for executables on the
+" path. By default, of course, checks are enabled. If {enable} is 0, they will
+" be disabled. If 1, normal behavior with IsAvailable checking is restored.
+function! codefmt#SetWhetherToPerformIsAvailableChecksForTesting(enable) abort
+  let s:check_formatters_available = a:enable
 endfunction

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -35,6 +35,10 @@ endif
 ""
 " The path to the autopep8 executable.
 call s:plugin.Flag('autopep8_executable', 'autopep8')
+" Invalidate cache of detected autopep8 version when this is changed, regardless
+" of {value} arg.
+call s:plugin.flags.autopep8_executable.AddCallback(
+    \ maktaba#function#FromExpr('codefmt#InvalidateAutopep8Version()'), 0)
 
 ""
 " The path to the clang-format executable.

--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -1,26 +1,21 @@
-Install dependencies and setup maktaba:
+This file demonstrates hooks for automatically formatting code on save.
+
+We'll set up codefmt and configure the vroom environment, then jump into some
+examples. If you haven't seen the setup code below yet, read through main.vroom
+briefly.
 
   :set nocompatible
   :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
   :execute 'source' g:repo . '/bootstrap.vim'
   :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
-  :filetype plugin on
-
-We'll stub out codefmt to not care whether certain executables are installed on
-your system.
 
   :call codefmt#DisableIsAvailableChecksForTesting()
 
 
-You can use the AutoFormatBuffer command to enable automatic code formatting
-when you save a file with a given filetype.
+By default, nothing special happens when you save a buffer.
 
-  :silent file foo.cc
-  :set filetype=cpp
   % void f() {int i; SomeFunction(parameter,// comment<CR>
   |i);}
-
-By default, this is disabled.
 
   :doautocmd BufWritePre
   void f() {int i; SomeFunction(parameter,// comment
@@ -29,40 +24,17 @@ By default, this is disabled.
 
 
 
-You can use the AutoFormatBuffer command.
+You can use the AutoFormatBuffer command to enable automatic code formatting
+when you save the current buffer. This combined with vim autocommands gives you
+the flexibility to automatically format certain buffers based on path, filetype,
+or whatever conditions you want to trigger on.
 
-  :silent file foo.cc
-  :set filetype=cpp
-  :AutoFormatBuffer
-  % void f() {int i; SomeFunction(parameter,// comment<CR>
-  |i);}
-
-  :doautocmd BufWritePre
-  ! clang-format -style .* -assume-filename .*foo.cc .*2>.*
-  $ void f() {
-  $   int i;
-  $   SomeFunction(parameter,  // comment
-  $                i);
-  $ }
-  void f() {
-    int i;
-    SomeFunction(parameter,  // comment
-                 i);
-  }
-  @end
-
-
-
-You can also use the AutoFormatBuffer command with an explicit formatter.
-
-  :silent file foo.cc
-  :set filetype=foo
   :AutoFormatBuffer clang-format
   % void f() {int i; SomeFunction(parameter,// comment<CR>
   |i);}
 
   :doautocmd BufWritePre
-  ! clang-format -style .* -assume-filename .*foo.cc .*2>.*
+  ! clang-format .*
   $ void f() {
   $   int i;
   $   SomeFunction(parameter,  // comment
@@ -75,13 +47,21 @@ You can also use the AutoFormatBuffer command with an explicit formatter.
   }
   @end
 
+Subsequent :FormatCode and :FormatLines invocations will also default to this
+same formatter.
 
+  :FormatCode
+  ! clang-format .*
+  $ void f() {
+  $   int i;
+  $   SomeFunction(parameter,  // comment
+  $                i);
+  $ }
 
-You can disable AutoFormatBuffer with NoAutoFormatBuffer.
+You can disable it for the current buffer with :NoAutoFormatBuffer. After that,
+the buffer will go back to doing nothing special when you save.
 
-  :silent file foo.cc
-  :set filetype=cpp
-  :AutoFormatBuffer
+  :%delete
   :NoAutoFormatBuffer
   % void f() {int i; SomeFunction(parameter,// comment<CR>
   |i);}
@@ -90,3 +70,15 @@ You can disable AutoFormatBuffer with NoAutoFormatBuffer.
   void f() {int i; SomeFunction(parameter,// comment
   i);}
   @end
+
+
+
+If you don't specify an explicit formatter as an argument to :AutoFormatBuffer,
+the default for the current buffer will be used.
+
+  :set filetype=go
+  :AutoFormatBuffer
+
+  :doautocmd BufWritePre
+  ! gofmt .*
+  $ 

--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -9,7 +9,7 @@ briefly.
   :execute 'source' g:repo . '/bootstrap.vim'
   :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
 
-  :call codefmt#DisableIsAvailableChecksForTesting()
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 
 
 By default, nothing special happens when you save a buffer.

--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -78,7 +78,8 @@ the default for the current buffer will be used.
 
   :set filetype=go
   :AutoFormatBuffer
+  % f()
 
   :doautocmd BufWritePre
   ! gofmt .*
-  $ 
+  $ f()

--- a/vroom/autopep8.vroom
+++ b/vroom/autopep8.vroom
@@ -1,0 +1,115 @@
+The built-in autopep8 formatter knows how to format python code.
+
+We'll set up codefmt and configure the vroom environment, then jump into some
+examples. If you haven't seen the setup code below yet, read through main.vroom
+briefly.
+
+  :set nocompatible
+  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
+  :execute 'source' g:repo . '/bootstrap.vim'
+  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+
+  :let g:repeat_calls = []
+  :function FakeRepeat(...)<CR>
+  |  call add(g:repeat_calls, a:000)<CR>
+  :endfunction
+  :call maktaba#test#Override('repeat#set', 'FakeRepeat')
+
+  :call codefmt#DisableIsAvailableChecksForTesting()
+
+
+The autopep8 formatter expects the autopep8 executable to be installed on your
+system.
+
+  :FormatCode autopep8
+  ! autopep8 .*
+  $ 
+
+The name or path of the autopep8 executable can be configured via the
+autopep8_executable flag if the default of "autopep8" doesn't work.
+
+  :Glaive codefmt autopep8_executable='autopep20'
+  :FormatCode autopep8
+  ! autopep20 .*
+  $ 
+  :Glaive codefmt autopep8_executable='autopep8'
+
+
+You can format any buffer with autopep8 specifying the formatter explicitly.
+
+  % if True: pass
+
+  :FormatCode autopep8
+  ! autopep8 --version 2>(.*)
+  $ echo "autopep8 1.0" > \1 (command)
+  ! autopep8 .* - .*
+  $ if True:
+  $     pass
+  if True:
+      pass
+  @end
+
+Notice the "autopep8 --version" syscall. The autopep8 formatter checks the
+version of the autopep8 executable to detect whether it natively supports range
+formatting. It caches the result, so it only does this once per vim session.
+We'll take a closer look at that below.
+
+
+The python filetype will use the autopep8 formatter by default.
+
+  :set filetype=python
+  :FormatCode
+  ! autopep8 .*
+  $ 
+
+  :set filetype=
+
+It can format specific line ranges of code using :FormatLines.
+
+  % some_tuple=(   1,2, 3,'a'  );<CR>
+  |if bar : bar+=1;  bar=bar* bar<CR>
+  |else: bar-=1;
+
+  :2,3FormatLines autopep8
+  ! autopep8 --range 2 3 - .*
+  $ some_tuple=(   1,2, 3,'a'  );
+  $ if bar:
+  $     bar += 1
+  $     bar = bar * bar
+  $ else:
+  $     bar -= 1
+  some_tuple=(   1,2, 3,'a'  );
+  if bar:
+      bar += 1
+      bar = bar * bar
+  else:
+      bar -= 1
+  @end
+
+Notice the --range argument. It's only supported by autopep8 1.0 and higher, and
+it appeared in the command line because the formatter detected autopep8 version
+1.0 when it was first invoked, earlier in this file. Now let's check what it
+does for older versions of autopep8.
+
+  @clear
+  :call codefmt#ForgetAutopep8VersionForTesting()
+  % some_tuple=(   1,2, 3,'a'  );<CR>
+  |if bar : bar+=1;  bar=bar* bar<CR>
+  |else: bar-=1;
+
+  :3,3FormatLines autopep8
+  ! autopep8 --version 2>(.*)
+  $ echo "autopep8 0.9" > \1 (command)
+  ! autopep8 - 2>.*
+  $ else:
+  $     bar -= 1
+  some_tuple=(   1,2, 3,'a'  );
+  if bar : bar+=1;  bar=bar* bar
+  else:
+      bar -= 1
+  @end
+
+It didn't pass the --range arg this time. Notice that it also only output part
+of the file, because this time only the range being formatted was passed to it
+(in this case, just line 3). This fallback range formatting behavior isn't
+perfect, but it does okay for most ranges.

--- a/vroom/autopep8.vroom
+++ b/vroom/autopep8.vroom
@@ -15,7 +15,7 @@ briefly.
   :endfunction
   :call maktaba#test#Override('repeat#set', 'FakeRepeat')
 
-  :call codefmt#DisableIsAvailableChecksForTesting()
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 
 
 The autopep8 formatter expects the autopep8 executable to be installed on your
@@ -38,9 +38,14 @@ autopep8_executable flag if the default of "autopep8" doesn't work.
 
   :Glaive codefmt autopep8_executable='autopep20'
   :FormatCode autopep8
+  ! autopep20 --version 2>(.*)
+  $ echo "autopep8 1.0" > \1 (command)
   ! autopep20 .*
   $ f()
   :Glaive codefmt autopep8_executable='autopep8'
+
+Any time this flag is changed, the cached version is invalidated and checked
+fresh on the next format invocation.
 
 
 You can format any buffer with autopep8 specifying the formatter explicitly.
@@ -49,6 +54,8 @@ You can format any buffer with autopep8 specifying the formatter explicitly.
   % if True: pass
 
   :FormatCode autopep8
+  ! autopep8 --version 2>(.*)
+  $ echo "autopep8 1.0" > \1 (command)
   ! autopep8 .* - .*
   $ if True:
   $     pass
@@ -93,11 +100,13 @@ It can format specific line ranges of code using :FormatLines.
 
 Notice the --range argument. It's only supported by autopep8 1.0 and higher, and
 it appeared in the command line because the formatter detected autopep8 version
-1.0 when it was first invoked, earlier in this file. Now let's check what it
-does for older versions of autopep8.
+1.0 when it was first invoked, earlier in this file.
+
+Now let's check what it does for older versions of autopep8. Remember, setting
+the autopep8_executable flag makes the formatter forget any cached version.
 
   @clear
-  :call codefmt#ForgetAutopep8VersionForTesting()
+  :Glaive codefmt autopep8_executable='autopep8'
   % some_tuple=(   1,2, 3,'a'  );<CR>
   |if bar : bar+=1;  bar=bar* bar<CR>
   |else: bar-=1;

--- a/vroom/autopep8.vroom
+++ b/vroom/autopep8.vroom
@@ -21,9 +21,17 @@ briefly.
 The autopep8 formatter expects the autopep8 executable to be installed on your
 system.
 
+  % f()
   :FormatCode autopep8
+  ! autopep8 --version 2>(.*)
+  $ echo "autopep8 1.0" > \1 (command)
   ! autopep8 .*
-  $ 
+  $ f()
+
+Notice the "autopep8 --version" syscall. The autopep8 formatter checks the
+version of the autopep8 executable to detect whether it natively supports range
+formatting. It caches the result, so it only does this once per vim session.
+We'll take a closer look at that below.
 
 The name or path of the autopep8 executable can be configured via the
 autopep8_executable flag if the default of "autopep8" doesn't work.
@@ -31,17 +39,16 @@ autopep8_executable flag if the default of "autopep8" doesn't work.
   :Glaive codefmt autopep8_executable='autopep20'
   :FormatCode autopep8
   ! autopep20 .*
-  $ 
+  $ f()
   :Glaive codefmt autopep8_executable='autopep8'
 
 
 You can format any buffer with autopep8 specifying the formatter explicitly.
 
+  @clear
   % if True: pass
 
   :FormatCode autopep8
-  ! autopep8 --version 2>(.*)
-  $ echo "autopep8 1.0" > \1 (command)
   ! autopep8 .* - .*
   $ if True:
   $     pass
@@ -49,23 +56,21 @@ You can format any buffer with autopep8 specifying the formatter explicitly.
       pass
   @end
 
-Notice the "autopep8 --version" syscall. The autopep8 formatter checks the
-version of the autopep8 executable to detect whether it natively supports range
-formatting. It caches the result, so it only does this once per vim session.
-We'll take a closer look at that below.
-
-
 The python filetype will use the autopep8 formatter by default.
+
+  @clear
+  % pass
 
   :set filetype=python
   :FormatCode
   ! autopep8 .*
-  $ 
+  $ pass
 
   :set filetype=
 
 It can format specific line ranges of code using :FormatLines.
 
+  @clear
   % some_tuple=(   1,2, 3,'a'  );<CR>
   |if bar : bar+=1;  bar=bar* bar<CR>
   |else: bar-=1;

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -22,9 +22,10 @@ briefly.
 The clang-format formatter expects the clang-format executable to be installed
 on your system (version 3.4 or newer).
 
+  % f();
   :FormatCode clang-format
   ! clang-format .*
-  $ 
+  $ f();
 
 The name or path of the clang-format executable can be configured via the
 clang_format_executable flag if the default of "clang-format" doesn't work.
@@ -32,12 +33,13 @@ clang_format_executable flag if the default of "clang-format" doesn't work.
   :Glaive codefmt clang_format_executable='clang-format-3.4'
   :FormatCode clang-format
   ! clang-format-3.4 .*
-  $ 
+  $ f();
   :Glaive codefmt clang_format_executable='clang-format'
 
 
 You can format any buffer with clang-format specifying the formatter explicitly.
 
+  @clear
   % void f() {int i; SomeFunction(parameter,// comment<CR>
   |i);}
 
@@ -58,20 +60,23 @@ You can format any buffer with clang-format specifying the formatter explicitly.
 Several filetypes will use the clang-format formatter by default:
 cpp, javascript, and proto.
 
+  @clear
+  % f();
+
   :set filetype=cpp
   :FormatCode
   ! clang-format .*
-  $ 
+  $ f();
 
   :set filetype=javascript
   :FormatCode
   ! clang-format .*
-  $ 
+  $ f();
 
   :set filetype=proto
   :FormatCode
   ! clang-format .*
-  $ 
+  $ f();
 
   :set filetype=
 

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -1,0 +1,141 @@
+The built-in clang-format formatter knows how to format code for C/C++ and many
+C-like languages.
+
+We'll set up codefmt and configure the vroom environment, then jump into some
+examples. If you haven't seen the setup code below yet, read through main.vroom
+briefly.
+
+  :set nocompatible
+  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
+  :execute 'source' g:repo . '/bootstrap.vim'
+  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+
+  :let g:repeat_calls = []
+  :function FakeRepeat(...)<CR>
+  |  call add(g:repeat_calls, a:000)<CR>
+  :endfunction
+  :call maktaba#test#Override('repeat#set', 'FakeRepeat')
+
+  :call codefmt#DisableIsAvailableChecksForTesting()
+
+
+The clang-format formatter expects the clang-format executable to be installed
+on your system (version 3.4 or newer).
+
+  :FormatCode clang-format
+  ! clang-format .*
+  $ 
+
+The name or path of the clang-format executable can be configured via the
+clang_format_executable flag if the default of "clang-format" doesn't work.
+
+  :Glaive codefmt clang_format_executable='clang-format-3.4'
+  :FormatCode clang-format
+  ! clang-format-3.4 .*
+  $ 
+  :Glaive codefmt clang_format_executable='clang-format'
+
+
+You can format any buffer with clang-format specifying the formatter explicitly.
+
+  % void f() {int i; SomeFunction(parameter,// comment<CR>
+  |i);}
+
+  :FormatCode clang-format
+  ! clang-format -style file .*2>.*
+  $ void f() {
+  $   int i;
+  $   SomeFunction(parameter,  // comment
+  $                i);
+  $ }
+  void f() {
+    int i;
+    SomeFunction(parameter,  // comment
+                 i);
+  }
+  @end
+
+Several filetypes will use the clang-format formatter by default:
+cpp, javascript, and proto.
+
+  :set filetype=cpp
+  :FormatCode
+  ! clang-format .*
+  $ 
+
+  :set filetype=javascript
+  :FormatCode
+  ! clang-format .*
+  $ 
+
+  :set filetype=proto
+  :FormatCode
+  ! clang-format .*
+  $ 
+
+  :set filetype=
+
+It can format specific line ranges of code using :FormatLines.
+
+  @clear
+  % void f() {<CR>
+  |  int i = 2+2;<CR>
+  |  int i = 3+3;<CR>
+  |  int i = 4+4;<CR>
+  |}
+
+  :3,4FormatLines clang-format
+  ! clang-format -style file -lines 3:4 .*2>.*
+  $ void f() {
+  $   int i = 2+2;
+  $   int i = 3 + 3;
+  $   int i = 4 + 4;
+  $ }
+  void f() {
+    int i = 2+2;
+    int i = 3 + 3;
+    int i = 4 + 4;
+  }
+  @end
+
+
+
+You might have wondered where the "-style file" above comes from. The
+clang-format tool accepts a "style" option to control the formatting style. By
+default, "file" is used to indicate that clang-format should respect
+configuration in a .clang-format file in the project directory. You can control
+how style is selected via the clang_format_style flag. This flag accepts either
+a string value to use everywhere...
+
+  :Glaive codefmt clang_format_style='WebKit'
+
+  % f();
+  :FormatCode clang-format
+  ! clang-format -style WebKit .*2>.*
+  $ f();
+
+...or a callable that takes no arguments and returns a string style name for the
+current buffer.
+
+  :function MaybeWebkitStyle()<CR>
+  |  if stridx(expand('%:p'), '/WebKit/') != -1<CR>
+  |    return 'WebKit'<CR>
+  |  endif<CR>
+  |  return 'file'<CR>
+  |endfunction
+  :Glaive codefmt clang_format_style=`function('MaybeWebkitStyle')`
+
+  :silent file /foo/WebKit/foo.cc
+  :FormatCode clang-format
+  ! clang-format -style WebKit -assume-filename .*foo.cc .*2>.*
+  $ f();
+
+  :silent file /foo/foo.cc
+  :FormatCode clang-format
+  ! clang-format -style file -assume-filename .*foo.cc .*2>.*
+  $ f();
+
+  :Glaive codefmt clang_format_style='file'
+
+The -assume-filename arg passed above is also related, used by the clang-format
+tool to detect any custom style rules particular to the current file.

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -16,7 +16,7 @@ briefly.
   :endfunction
   :call maktaba#test#Override('repeat#set', 'FakeRepeat')
 
-  :call codefmt#DisableIsAvailableChecksForTesting()
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 
 
 The clang-format formatter expects the clang-format executable to be installed

--- a/vroom/gofmt.vroom
+++ b/vroom/gofmt.vroom
@@ -1,0 +1,115 @@
+The built-in gofmt formatter knows how to format go code.
+
+We'll set up codefmt and configure the vroom environment, then jump into some
+examples. If you haven't seen the setup code below yet, read through main.vroom
+briefly.
+
+  :set nocompatible
+  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
+  :execute 'source' g:repo . '/bootstrap.vim'
+  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+
+  :let g:repeat_calls = []
+  :function FakeRepeat(...)<CR>
+  |  call add(g:repeat_calls, a:000)<CR>
+  :endfunction
+  :call maktaba#test#Override('repeat#set', 'FakeRepeat')
+
+  :call codefmt#DisableIsAvailableChecksForTesting()
+
+
+The gofmt formatter expects the gofmt executable to be installed on your system.
+
+  :FormatCode gofmt
+  ! gofmt .*
+  $ 
+
+The name or path of the gofmt executable can be configured via the
+gofmt_executable flag if the default of "gofmt" doesn't work.
+
+  :Glaive codefmt gofmt_executable='mygofmt'
+  :FormatCode gofmt
+  ! mygofmt .*
+  $ 
+  :Glaive codefmt gofmt_executable='gofmt'
+
+
+You can format any buffer with gofmt specifying the formatter explicitly.
+
+  % package main;import "fmt"<CR>
+  |func main() { fmt.Printf("hello ")<CR>
+  |fmt.Printf("world\n") }
+
+  :FormatCode gofmt
+  ! gofmt .*2>.*
+  $ package main
+  $ 
+  $ import "fmt"
+  $ 
+  $ func main() {
+  $ \tfmt.Printf("hello ")
+  $ \tfmt.Printf("world\\n")
+  $ }
+  package main
+  &
+  import "fmt"
+  &
+  func main() {
+  	fmt.Printf("hello ")
+  	fmt.Printf("world\n")
+  }
+  @end
+
+The go filetype will use the gofmt formatter by default.
+
+  :set filetype=go
+  :FormatCode
+  ! gofmt .*
+  $ 
+
+  :set filetype=
+
+It can format specific line ranges of code using :FormatLines.
+
+  % package main;import "fmt"<CR>
+  |func main() { fmt.Printf("hello ")<CR>
+  |fmt.Printf("world\n") }
+
+  :2,3FormatLines gofmt
+  ! gofmt .*2>.*
+  $ func main() {
+  $ \tfmt.Printf("hello ")
+  $ \tfmt.Printf("world\\n")
+  $ }
+  package main;import "fmt"
+  func main() {
+  	fmt.Printf("hello ")
+  	fmt.Printf("world\n")
+  }
+  @end
+
+NOTE: the gofmt formatter does not natively support range formatting, so there
+are certain limitations like not being able to format misaligned braces.
+
+
+
+You can also use goimports (or any other gofmt-like binary) to add imports as
+needed by setting the gofmt_executable flag:
+
+  :Glaive codefmt gofmt_executable='goimports'
+  % package main<CR>
+  |func main() { fmt.Printf("hello world\n") }
+
+  :FormatCode gofmt
+  ! goimports .*2>.*
+  $ package main
+  $ 
+  $ import "fmt"
+  $ 
+  $ func main() { fmt.Printf("hello world\\n") }
+  package main
+  &
+  import "fmt"
+  &
+  func main() { fmt.Printf("hello world\n") }
+  @end

--- a/vroom/gofmt.vroom
+++ b/vroom/gofmt.vroom
@@ -20,9 +20,10 @@ briefly.
 
 The gofmt formatter expects the gofmt executable to be installed on your system.
 
+  % f()
   :FormatCode gofmt
   ! gofmt .*
-  $ 
+  $ f()
 
 The name or path of the gofmt executable can be configured via the
 gofmt_executable flag if the default of "gofmt" doesn't work.
@@ -30,12 +31,13 @@ gofmt_executable flag if the default of "gofmt" doesn't work.
   :Glaive codefmt gofmt_executable='mygofmt'
   :FormatCode gofmt
   ! mygofmt .*
-  $ 
+  $ f()
   :Glaive codefmt gofmt_executable='gofmt'
 
 
 You can format any buffer with gofmt specifying the formatter explicitly.
 
+  @clear
   % package main;import "fmt"<CR>
   |func main() { fmt.Printf("hello ")<CR>
   |fmt.Printf("world\n") }
@@ -62,15 +64,19 @@ You can format any buffer with gofmt specifying the formatter explicitly.
 
 The go filetype will use the gofmt formatter by default.
 
+  @clear
+  % f()
+
   :set filetype=go
   :FormatCode
   ! gofmt .*
-  $ 
+  $ f()
 
   :set filetype=
 
 It can format specific line ranges of code using :FormatLines.
 
+  @clear
   % package main;import "fmt"<CR>
   |func main() { fmt.Printf("hello ")<CR>
   |fmt.Printf("world\n") }

--- a/vroom/gofmt.vroom
+++ b/vroom/gofmt.vroom
@@ -15,7 +15,7 @@ briefly.
   :endfunction
   :call maktaba#test#Override('repeat#set', 'FakeRepeat')
 
-  :call codefmt#DisableIsAvailableChecksForTesting()
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 
 
 The gofmt formatter expects the gofmt executable to be installed on your system.

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -124,10 +124,12 @@ won't take arguments, anyway. For several filetypes, codefmt selects an
 appropriate formatter by default. For instance, the built-in gofmt formatter
 will be used by default for the go filetype.
 
+  @clear
+  % f()
   :set filetype=go
   :FormatCode
   ! gofmt .*
-  $ 
+  $ f()
 
 You can also configure which formatter to use on a buffer-by-buffer basis via
 b:codefmt_formatter, which will take precedence over the built-in defaulting.
@@ -135,7 +137,7 @@ b:codefmt_formatter, which will take precedence over the built-in defaulting.
   :let b:codefmt_formatter = 'clang-format'
   :FormatCode
   ! clang-format .*
-  $ 
+  $ f()
   :unlet b:codefmt_formatter
 
 If no default formatter is available for a buffer, you'll just see an error.

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -1,13 +1,28 @@
-Install dependencies and setup maktaba:
+Vim is useful for editing source code and has some primitive features for
+formatting code. Most of these are based on error-prone heuristics and are
+better for getting close-enough formatting quickly as you edit, not for closely
+adhering to particular formatting guidelines.
+
+The utilities in codefmt hook vim up to high-quality external formatters like
+clang-format that you can trigger on-demand or when saving buffers.
+
+This file demonstrates the basics of codefmt usage. Other files in this
+directory cover various topics of codefmt usage:
+
+* autopep8.vroom - Configuring and using the built-in autopep8 formatter
+* clangformat.vroom - Configuring and using the built-in clang-format formatter
+* gofmt.vroom - Configuring and using the built-in gofmt formatter
+* autocmd.vroom - Automatic hooks like format-on-save
+
+In order for these tests to work, maktaba and codefmtlib MUST be in the same
+parent directory as codefmt. Given that that's the case, all we have to do is
+source the codefmt bootstrap file.
 
   :set nocompatible
   :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
   :execute 'source' g:repo . '/bootstrap.vim'
   :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
-  :filetype plugin on
 
-
-This plugin allows formatting code via tools like clang-format.
 
 It integrates with vim-repeat if available for improved repeating support. We'll
 stub that out for vroom.
@@ -18,45 +33,19 @@ stub that out for vroom.
   :endfunction
   :call maktaba#test#Override('repeat#set', 'FakeRepeat')
 
-
-Before we stub out availability checks, test :FormatCode for unavailable plugins
-returns a decent error.
-
-  :silent file foo.fake
-  :let fake_format = {'name': 'fake_format', 'setup_instructions': 'FAKE OUT'}
-  :function fake_format.IsAvailable()<CR>
-  |  return 0<CR>
-  |endfunction
-  :function fake_format.AppliesToBuffer()<CR>
-  |  return &filetype is# 'fake'<CR>
-  |endfunction
-  :function fake_format.Format()<CR>
-  |endfunction
-  :call codefmtlib#AddFormatter(fake_format)
-  :set filetype=fake
-  % void f() {int i; SomeFunction(parameter,// comment<CR>
-  |i);}
-
-  :FormatCode
-  ~ Formatter "fake_format" is not available. Setup instructions: FAKE OUT
-
-
-Now, we'll stub it out to not care whether certain executables are installed on
+We'll also stub it out to not care whether certain executables are installed on
 your system.
 
   :call codefmt#DisableIsAvailableChecksForTesting()
 
 
 This plugin defines a :FormatCode command that can be used to reformat buffers.
-It can format C++ code using clang-format.
 
-  :silent file foo.cc
-  :set filetype=cpp
   % void f() {int i; SomeFunction(parameter,// comment<CR>
   |i);}
 
-  :FormatCode
-  ! clang-format -style file -assume-filename .*foo.cc .*2>.*
+  :FormatCode clang-format
+  ! clang-format .*
   $ void f() {
   $   int i;
   $   SomeFunction(parameter,  // comment
@@ -73,8 +62,6 @@ It can format C++ code using clang-format.
 
 To format specific line ranges of C++ code using clang-format, use :FormatLines.
 
-  :silent file foo.cc
-  :set filetype=cpp
   % void f() {<CR>
   |  int i = 2+2;<CR>
   |  int i = 3+3;<CR>
@@ -83,8 +70,8 @@ To format specific line ranges of C++ code using clang-format, use :FormatLines.
 
   :let g:repeat_calls = []
 
-  :3,4FormatLines
-  ! clang-format -style file -assume-filename .*foo.cc -lines 3:4 .*2>.*
+  :3,4FormatLines clang-format
+  ! clang-format .* -lines 3:4.*
   $ void f() {
   $   int i = 2+2;
   $   int i = 3 + 3;
@@ -105,249 +92,99 @@ the same number of lines again.
 
 
 
-You might have wondered where the "-style file" above comes from. The
-clang-format tool accepts a "style" option to control the formatting style. By
-default, "file" is used to indicate that clang-format should respect
-configuration in a .clang-format file in the project directory. You can control
-how style is selected via the clang_format_style flag. This flag accepts either
-a string value to use everywhere...
-
-  :Glaive codefmt clang_format_style=WebKit
-
-  % f();
-  :FormatCode clang-format
-  ! clang-format -style WebKit .*2>.*
-  $ f();
-
-...or a callable that takes no arguments and returns a string style name for the
-current buffer.
-
-  :function MaybeWebkitStyle()<CR>
-  |  if stridx(expand('%:p'), '/WebKit/') != -1<CR>
-  |    return 'WebKit'<CR>
-  |  endif<CR>
-  |  return 'file'<CR>
-  |endfunction
-  :Glaive codefmt clang_format_style=`function('MaybeWebkitStyle')`
-
-  :silent file /foo/WebKit/foo.cc
-  :FormatCode clang-format
-  ! clang-format -style WebKit -assume-filename .*foo.cc .*2>.*
-  $ f();
-
-  :silent file /foo/foo.cc
-  :FormatCode clang-format
-  ! clang-format -style file -assume-filename .*foo.cc .*2>.*
-  $ f();
-
-  :Glaive codefmt clang_format_style=file
-
-
-
-Protocol buffer definitions can also be reformatted, again using clang-format.
-
-  :silent file foo.proto
-  :set filetype=proto
-  % message Foo {message Bar  {<CR>
-  |enum Baz{ X= 1;Y  =2;  } optional int64 a=1; //comment<CR>
-  |           repeated Baz b = 2;<CR>
-  |}}
-
-  :FormatCode
-  ! clang-format -style file -assume-filename .*foo.proto .*2>.*
-  $ message Foo {
-  $   message Bar {
-  $     enum Baz {
-  $       X = 1;
-  $       Y = 2;
-  $     }
-  $     optional int64 a = 1;  // comment
-  $     repeated Baz b = 2;
-  $   }
-  $ }
-  message Foo {
-    message Bar {
-      enum Baz {
-        X = 1;
-        Y = 2;
-      }
-      optional int64 a = 1;  // comment
-      repeated Baz b = 2;
-    }
-  }
-  @end
-
-
-
-It can format Go code using gofmt.
-
-  :silent file foo.go
-  :set filetype=go
-  % package main;import "fmt"<CR>
-  |func main() { fmt.Printf("hello ")<CR>
-  |fmt.Printf("world\n") }
-
-  :FormatCode
-  ! gofmt .*2>.*
-  $ package main
-  $ 
-  $ import "fmt"
-  $ 
-  $ func main() {
-  $ \tfmt.Printf("hello ")
-  $ \tfmt.Printf("world\\n")
-  $ }
-  package main
-  &
-  import "fmt"
-  &
-  func main() {
-  	fmt.Printf("hello ")
-  	fmt.Printf("world\n")
-  }
-  @end
-
-
-
-Go code also supports formatting a range with :FormatLines.
-
-  :silent file foo.go
-  :set filetype=go
-  % package main;import "fmt"<CR>
-  |func main() { fmt.Printf("hello ")<CR>
-  |fmt.Printf("world\n") }
-
-  :2,3FormatLines
-  ! gofmt .*2>.*
-  $ func main() {
-  $ \tfmt.Printf("hello ")
-  $ \tfmt.Printf("world\\n")
-  $ }
-  package main;import "fmt"
-  func main() {
-  	fmt.Printf("hello ")
-  	fmt.Printf("world\n")
-  }
-  @end
-
-
-
-You can also use goimports (or any other gofmt-like binary) to add imports as
-needed by setting the gofmt_executable flag:
-
-  :silent file foo.go
-  :set filetype=go
-  :Glaive codefmt gofmt_executable='goimports'
-  % package main<CR>
-  |func main() { fmt.Printf("hello world\n") }
-
-  :FormatCode
-  ! goimports .*2>.*
-  $ package main
-  $ 
-  $ import "fmt"
-  $ 
-  $ func main() { fmt.Printf("hello world\\n") }
-  package main
-  &
-  import "fmt"
-  &
-  func main() { fmt.Printf("hello world\n") }
-  @end
-
-
-
 Formatting doesn't move the cursor.
 
-  :silent file foo.cc
-  :set filetype=cpp
   % void f() {int i;<CR>
   |SomeFunction();<CR>
   |}
 
-  > /Fun<CR>
+  > 1G/Fun<CR>
   :echomsg line('.') . ',' . col('.')
   ~ 2,5
-  :FormatCode
-  ! clang-format -style file -assume-filename .*foo.cc .*2>.*
+  :FormatCode clang-format
+  ! clang-format .*
   $ void f() {
   $   int i;
   $   SomeFunction();
   $ }
-  :echomsg line('.') . ',' . col('.')
-  ~ 2,5
   void f() {
     int i;
     SomeFunction();
   }
+  @end
+  :echomsg line('.') . ',' . col('.')
+  ~ 2,5
 
 
 
-Test :FormatCode [formatter] with unavailable formatter
+The examples above pass an explicit formatter argument to :FormatCode and
+:FormatLines to select which formatter to use. In day-to-day editing, that would
+get old pretty fast, and you'd probably be invoking it through key mappings that
+won't take arguments, anyway. For several filetypes, codefmt selects an
+appropriate formatter by default. For instance, the built-in gofmt formatter
+will be used by default for the go filetype.
 
-  :silent file BUILD
-  :set filetype=blazebuild
-  % java_package(name="foo", deps=[":bar", ":baz"])
+  :set filetype=go
+  :FormatCode
+  ! gofmt .*
+  $ 
 
-  :FormatCode foo
-  ~ "foo" is not a supported formatter.
+You can also configure which formatter to use on a buffer-by-buffer basis via
+b:codefmt_formatter, which will take precedence over the built-in defaulting.
 
+  :let b:codefmt_formatter = 'clang-format'
+  :FormatCode
+  ! clang-format .*
+  $ 
+  :unlet b:codefmt_formatter
 
+If no default formatter is available for a buffer, you'll just see an error.
 
-Test :FormatCode for unknown filetype.
-
-  :silent file FOO
-  :set filetype=bar
-  % java_package(name="foo", deps=[":bar", ":baz"])
-
+  :set filetype=
   :FormatCode
   ~ Not available. codefmt doesn't have a default formatter for this buffer.
 
+Similarly, you'll see an error if an explicit formatter name isn't recognized.
 
+  :FormatCode nonexistentformatter
+  ~ "nonexistentformatter" is not a supported formatter.
 
-Test :FormatCode [formatter]
+If a formatter name is recognized but the formatter isn't available (isn't
+configured or is missing dependencies), codefmt will print setup instructions
+for that formatter.
 
-  :silent file foo.cc
-  :set filetype=
-  % void f() {int i; SomeFunction(parameter,// comment<CR>
-  |i);}
+  :call codefmt#DontDisableIsAvailableChecksForTesting()
 
-  :FormatCode clang-format
-  ! clang-format -style file -assume-filename .*foo.cc .*2>.*
-  $ void f() {
-  $   int i;
-  $   SomeFunction(parameter,  // comment
-  $                i);
-  $ }
-  void f() {
-    int i;
-    SomeFunction(parameter,  // comment
-                 i);
-  }
-  @end
+  :let fake_format = {'name': 'fake-format', 'setup_instructions': 'RTFM'}
+  :function fake_format.IsAvailable()<CR>
+  |  return 0<CR>
+  |endfunction
+  :function fake_format.AppliesToBuffer()<CR>
+  |  return &filetype is# 'fake'<CR>
+  |endfunction
+  :function fake_format.Format()<CR>
+  |endfunction
+  :call codefmtlib#AddFormatter(fake_format)
 
+  :FormatCode fake-format
+  ~ Formatter "fake-format" is not available. Setup instructions: RTFM
 
+It will print a similar message if the default formatter for the buffer is not
+available.
 
-Test :FormatCode for unknown filetype with explicitly set formatter.
-
-  :silent file foo.cc
-  :set filetype=bar
-  % void f() {int i; SomeFunction(parameter,// comment<CR>
-  |i);}
-
-  :call maktaba#ensure#IsFalse(codefmt#IsFormatterAvailable())
-  :let b:codefmt_formatter = "clang-format"
-  :call maktaba#ensure#IsTrue(codefmt#IsFormatterAvailable())
+  :silent file foo.fake
+  :set filetype=fake
   :FormatCode
-  ! clang-format -style .* -assume-filename .*foo.cc .*2>.*
-  $ void f() {
-  $   int i;
-  $   SomeFunction(parameter,  // comment
-  $                i);
-  $ }
-  void f() {
-    int i;
-    SomeFunction(parameter,  // comment
-                 i);
-  }
-  @end
+  ~ Formatter "fake-format" is not available. Setup instructions: RTFM
+
+If there are multiple formatters that apply to the current buffer but none of
+them are available, the message will show a line for each.
+
+  :let fake_format2 = copy(fake_format)
+  :let fake_format2.name = 'fake-format2'
+  :let fake_format2.setup_instructions = 'LMGTFY'
+  :call codefmtlib#AddFormatter(fake_format2)
+
+  :FormatCode
+  ~ Formatter "fake-format" is not available. Setup instructions: RTFM
+  ~ Formatter "fake-format2" is not available. Setup instructions: LMGTFY

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -36,7 +36,7 @@ stub that out for vroom.
 We'll also stub it out to not care whether certain executables are installed on
 your system.
 
-  :call codefmt#DisableIsAvailableChecksForTesting()
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 
 
 This plugin defines a :FormatCode command that can be used to reformat buffers.
@@ -155,7 +155,7 @@ If a formatter name is recognized but the formatter isn't available (isn't
 configured or is missing dependencies), codefmt will print setup instructions
 for that formatter.
 
-  :call codefmt#DontDisableIsAvailableChecksForTesting()
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(1)
 
   :let fake_format = {'name': 'fake-format', 'setup_instructions': 'RTFM'}
   :function fake_format.IsAvailable()<CR>


### PR DESCRIPTION
Cleans up vroom files so they explain what they're doing more clearly and introduce concepts in a more natural order. Cuts down on a lot of repetition by leaving out details that don't relate to the feature being demonstrated/tested, like using more wildcards in syscall lines and formatting empty buffers in places.

Also adds a lot of coverage and adds testing for autopep8 which previously had none.

Fixes #11.