### PR TITLE
Use Maktaba's extension registry rather than codefmtlib.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 env:
   matrix:
     # This Maktaba version should match the minimum required in bootstrap.vim.
-    - CI_TARGET=vim MAKTABA_VERSION=1.8.0
+    - CI_TARGET=vim MAKTABA_VERSION=1.9.0
     - CI_TARGET=vim MAKTABA_VERSION=master
     - CI_TARGET=neovim MAKTABA_VERSION=master
 before_script:
@@ -21,7 +21,6 @@ before_script:
   - sudo dpkg -i ./vroom_0.12.0-1_all.deb
   - git clone -b ${MAKTABA_VERSION} https://github.com/google/vim-maktaba.git ../maktaba/
   - git clone https://github.com/google/vim-glaive.git ../glaive/
-  - git clone https://github.com/google/vim-codefmtlib.git ../codefmtlib/
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
   - vroom $VROOM_ARGS --crawl ./vroom/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-codefmt is a utility for syntax-aware code formatting.  codefmt relies on
-[codefmtlib](https://github.com/google/vim-codefmtlib) for registration and
-management of formatting plugins.
+codefmt is a utility for syntax-aware code formatting.  It contains several
+built-in formatters, and allows new formatters to be registered by other
+plugins.
 
 For details, see the executable documentation in the `vroom/` directory or the
 helpfiles in the `doc/` directory. The helpfiles are also available via
@@ -34,7 +34,6 @@ plugin-adding command is `Plugin`.
 " Add maktaba and codefmt to the runtimepath.
 " (The latter must be installed before it can be used.)
 Plugin 'google/vim-maktaba'
-Plugin 'google/vim-codefmtlib'
 Plugin 'google/vim-codefmt'
 " Also add Glaive, which is used to configure codefmt's maktaba flags. See
 " `:help :Glaive` for usage.
@@ -44,8 +43,8 @@ call glaive#Install()
 Glaive codefmt plugin[mappings]
 ```
 
-Make sure you have updated maktaba recently. Older versions had an issue
-detecting installed libraries.
+Make sure you have updated maktaba recently. Codefmt depends upon maktaba
+to register formatters.
 
 # Installing and configuring formatters
 

--- a/addon-info.json
+++ b/addon-info.json
@@ -4,7 +4,6 @@
   "author": "Google",
   "repository": {"type": "git", "url": "git://github.com/google/vim-codefmt"},
   "dependencies": {
-    "maktaba": {"type": "git", "url": "git://github.com/google/vim-maktaba"},
-    "codefmtlib": {"type": "git", "url": "git://github.com/google/vim-codefmtlib"}
+    "maktaba": {"type": "git", "url": "git://github.com/google/vim-maktaba"}
   }
 }

--- a/bootstrap.vim
+++ b/bootstrap.vim
@@ -54,7 +54,7 @@ if !exists('*maktaba#compatibility#Disable')
       unlet s:rtpsave
       " We'd like to use maktaba#error#Shout, but maktaba doesn't exist yet.
       echohl ErrorMsg
-      echomsg 'Maktaba not found, but codefmtlib requires it. Please either:'
+      echomsg 'Maktaba not found, but codefmt requires it. Please either:'
       echomsg '1. Place maktaba in the same directory as this plugin.'
       echomsg '2. Add maktaba to your runtimepath before using this plugin.'
       echomsg 'Maktaba can be found at https://github.com/google/vim-maktaba.'
@@ -63,8 +63,8 @@ if !exists('*maktaba#compatibility#Disable')
     endtry
   endtry
 endif
-if !maktaba#IsAtLeastVersion('1.8.0')
-  call maktaba#error#Shout('Codefmt requires maktaba version 1.8.0.')
+if !maktaba#IsAtLeastVersion('1.9.0')
+  call maktaba#error#Shout('Codefmt requires maktaba version 1.9.0.')
   call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
   call maktaba#error#Shout('Please update your maktaba install.')
 endif
@@ -81,7 +81,6 @@ function! s:InstallFromLocalDirs(plugin) abort
 endfunction
 
 call s:InstallFromLocalDirs('glaive')
-call s:InstallFromLocalDirs('codefmtlib')
 
 let s:codefmt_plugin = maktaba#plugin#GetOrInstall(s:codefmt_path)
 call s:codefmt_plugin.Load()

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -6,10 +6,11 @@ CONTENTS                                                    *codefmt-contents*
   1. Introduction..............................................|codefmt-intro|
   2. Configuration............................................|codefmt-config|
   3. Formatters...........................................|codefmt-formatters|
-  4. Commands...............................................|codefmt-commands|
-  5. Autocommands...........................................|codefmt-autocmds|
-  6. Functions.............................................|codefmt-functions|
-  7. Mappings...............................................|codefmt-mappings|
+  4. Dictionaries..............................................|codefmt-dicts|
+  5. Commands...............................................|codefmt-commands|
+  6. Autocommands...........................................|codefmt-autocmds|
+  7. Functions.............................................|codefmt-functions|
+  8. Mappings...............................................|codefmt-mappings|
 
 ==============================================================================
 INTRODUCTION                                                   *codefmt-intro*
@@ -84,6 +85,37 @@ The current list of defaults by filetype is:
   * c, cpp, proto, javascript: clang-format
   * go: gofmt
   * python: autopep8
+
+==============================================================================
+DICTIONARIES                                                   *codefmt-dicts*
+
+                                                           *codefmt.Formatter*
+Interface for applying formatting to lines of code.  Formatters are registered
+with codefmt using maktaba's standard extension registry:
+>
+  let l:codefmt_registry = maktaba#extension#GetRegistry('codefmt')
+  call l:codefmt_registry.AddExtension(l:formatter)
+<
+
+Formatters define these fields:
+  * name (string): The formatter name that will be exposed to users.
+  * setup_instructions (string, optional): A string explaining to users how to
+    make the plugin available if not already available.
+and these functions:
+  * IsAvailable() -> boolean: Whether the formatter is fully functional with
+    all dependencies available. Returns 0 only if setup_instructions have not
+    been followed.
+  * AppliesToBuffer() -> boolean: Whether the current buffer is of a type
+    normally formatted by this formatter. Normally based on 'filetype', but
+    could depend on buffer name or other properties.
+and should implement at least one of the following functions:
+  * Format(): Formats the current buffer directly.
+  * FormatRange({startline}, {endline}): Formats the current buffer, focusing
+    on the range of lines from {startline} to {endline}.
+  * FormatRanges({ranges}): Formats the current buffer, focusing on the given
+    ranges of lines. Each range should be a 2-item list of
+    [startline,endline].
+Formatters should implement the most specific format method that is supported.
 
 ==============================================================================
 COMMANDS                                                    *codefmt-commands*

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -14,7 +14,7 @@
 
 ""
 " @section Introduction, intro
-" @order intro config formatters commands autocmds functions mappings
+" @order intro config formatters dicts commands autocmds functions mappings
 " Provides a @command(FormatCode) command to intelligently reformat code.
 
 ""

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -14,9 +14,9 @@ directory cover various topics of codefmt usage:
 * gofmt.vroom - Configuring and using the built-in gofmt formatter
 * autocmd.vroom - Automatic hooks like format-on-save
 
-In order for these tests to work, maktaba and codefmtlib MUST be in the same
-parent directory as codefmt. Given that that's the case, all we have to do is
-source the codefmt bootstrap file.
+In order for these tests to work, maktaba MUST be in the same parent directory
+as codefmt. Given that that's the case, all we have to do is source the codefmt
+bootstrap file.
 
   :set nocompatible
   :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
@@ -151,6 +151,41 @@ Similarly, you'll see an error if an explicit formatter name isn't recognized.
   :FormatCode nonexistentformatter
   ~ "nonexistentformatter" is not a supported formatter.
 
+Formatters are registered with maktaba's extension registry. Each formatter
+must be a dict that has certain fields defined, as described in the codefmt
+docs.
+
+  :let formatter1 = {'name': 'formatter1'}
+  :function formatter1.IsAvailable()<CR>
+  |  return 0<CR>
+  |endfunction
+  :function formatter1.AppliesToBuffer()<CR>
+  |  return 0<CR>
+  |endfunction
+  :function formatter1.Format()<CR>
+  |endfunction
+  :call maktaba#extension#GetRegistry('codefmt').AddExtension(formatter1)
+
+If it isn't a dict, ERROR(WrongType) will be thrown.  If it's missing fields,
+ERROR(BadValue) will be shouted to the user.
+
+  :let registry = maktaba#extension#GetRegistry('codefmt')
+  :let add = maktaba#function#Method(registry, 'AddExtension')
+  :call maktaba#error#Try(add.WithArgs(0))
+  ~ ERROR(WrongType): Expected a dictionary. Got a number.
+
+  :call registry.AddExtension({})
+  ~ ERROR(BadValue): a:formatter is missing fields: name, IsAvailable,
+  | AppliesToBuffer
+
+If it doesn't have the right format functions, ERROR(BadValue) will be shouted.
+
+  :let formatter = deepcopy(formatter1)
+  :unlet formatter.Format
+  :call maktaba#extension#GetRegistry('codefmt').AddExtension(formatter)
+  ~ ERROR(BadValue): Formatter formatter1 has no format functions.  It must have
+  | at least one of Format, FormatRange, FormatRanges
+
 If a formatter name is recognized but the formatter isn't available (isn't
 configured or is missing dependencies), codefmt will print setup instructions
 for that formatter.
@@ -166,7 +201,7 @@ for that formatter.
   |endfunction
   :function fake_format.Format()<CR>
   |endfunction
-  :call codefmtlib#AddFormatter(fake_format)
+  :call maktaba#extension#GetRegistry('codefmt').AddExtension(fake_format)
 
   :FormatCode fake-format
   ~ Formatter "fake-format" is not available. Setup instructions: RTFM
@@ -185,8 +220,8 @@ them are available, the message will show a line for each.
   :let fake_format2 = copy(fake_format)
   :let fake_format2.name = 'fake-format2'
   :let fake_format2.setup_instructions = 'LMGTFY'
-  :call codefmtlib#AddFormatter(fake_format2)
+  :call maktaba#extension#GetRegistry('codefmt').AddExtension(fake_format2)
 
   :FormatCode
-  ~ Formatter "fake-format" is not available. Setup instructions: RTFM
   ~ Formatter "fake-format2" is not available. Setup instructions: LMGTFY
+  ~ Formatter "fake-format" is not available. Setup instructions: RTFM


### PR DESCRIPTION
This change removes the codefmt->codefmtlib dependency, replacing it with the new extension registry added in Maktaba 1.9.0.

In detail:
- Replace codefmtlib references with `maktaba#extensions`.
- Bump the requirements to Maktaba 1.9.0.
- Inline the documentation and EnsureFormatter() method from codefmtlib.
- Inline (and slightly adjust) some of the tests from codefmtlib.
- Register jsbeautify before clang-format so that clang-format is still the default formatter for filetype javascript. (codefmtlib was first-registration wins, maktaba#extensions is last-registration wins.)

Fixes #32.