### PR TITLE
Remove testing hacks and maktaba version check from bootstrap.vim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: generic
 env:
   matrix:
-    # This Maktaba version should match the minimum required in bootstrap.vim.
+    # This Maktaba version should match the minimum required in instant/flags.vim.
     - CI_TARGET=vim MAKTABA_VERSION=1.9.0
     - CI_TARGET=vim MAKTABA_VERSION=master
     - CI_TARGET=neovim MAKTABA_VERSION=master

--- a/bootstrap.vim
+++ b/bootstrap.vim
@@ -12,6 +12,9 @@
 " See the License for the specific language governing permissions and
 " limitations under the License.
 
+" This file can be sourced to install the plugin and its dependencies if no
+" plugin manager is available.
+
 let s:codefmt_path = expand('<sfile>:p:h')
 
 if !exists('*maktaba#compatibility#Disable')

--- a/bootstrap.vim
+++ b/bootstrap.vim
@@ -51,9 +51,4 @@ if !exists('*maktaba#compatibility#Disable')
     endtry
   endtry
 endif
-if !maktaba#IsAtLeastVersion('1.9.0')
-  call maktaba#error#Shout('Codefmt requires maktaba version 1.9.0.')
-  call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
-  call maktaba#error#Shout('Please update your maktaba install.')
-endif
 call maktaba#plugin#GetOrInstall(s:codefmt_path)

--- a/bootstrap.vim
+++ b/bootstrap.vim
@@ -14,18 +14,6 @@
 
 let s:codefmt_path = expand('<sfile>:p:h')
 
-function! s:FindAndAppendToRuntimePath(dir) abort
-    " We'd like to use maktaba#path#Join, but maktaba doesn't exist yet.
-    let s:slash = exists('+shellslash') && !&shellslash ? '\' : '/'
-    let s:guess1 = fnamemodify(s:codefmt_path, ':h') . s:slash . a:dir
-    let s:guess2 = fnamemodify(s:codefmt_path, ':h') . s:slash . 'vim-' . a:dir
-    if isdirectory(s:guess1)
-      let &runtimepath .= ',' . s:guess1
-    elseif isdirectory(s:guess2)
-      let &runtimepath .= ',' . s:guess2
-    endif
-endfunction
-
 if !exists('*maktaba#compatibility#Disable')
   try
     " To check if Maktaba is loaded we must try calling a maktaba function.
@@ -68,19 +56,4 @@ if !maktaba#IsAtLeastVersion('1.9.0')
   call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
   call maktaba#error#Shout('Please update your maktaba install.')
 endif
-
-function! s:InstallFromLocalDirs(plugin) abort
-  let l:parent_dir = fnamemodify(s:codefmt_path, ':h')
-  let l:guess1 = maktaba#path#Join([l:parent_dir, a:plugin])
-  let l:guess2 = maktaba#path#Join([l:parent_dir, 'vim-' . a:plugin])
-  if maktaba#path#Exists(s:guess1)
-    call maktaba#plugin#GetOrInstall(l:guess1).Load()
-  elseif maktaba#path#Exists(s:guess2)
-    call maktaba#plugin#GetOrInstall(l:guess2).Load()
-  endif
-endfunction
-
-call s:InstallFromLocalDirs('glaive')
-
-let s:codefmt_plugin = maktaba#plugin#GetOrInstall(s:codefmt_path)
-call s:codefmt_plugin.Load()
+call maktaba#plugin#GetOrInstall(s:codefmt_path)

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -32,6 +32,14 @@ if !s:enter
 endif
 
 
+" Shout if maktaba is too old. Done here to ensure it's always triggered.
+if !maktaba#IsAtLeastVersion('1.9.0')
+  call maktaba#error#Shout('Codefmt requires maktaba version 1.9.0.')
+  call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
+  call maktaba#error#Shout('Please update your maktaba install.')
+endif
+
+
 ""
 " The path to the autopep8 executable.
 call s:plugin.Flag('autopep8_executable', 'autopep8')

--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -1,8 +1,8 @@
 This file demonstrates hooks for automatically formatting code on save.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
 
 We'll set up codefmt and configure the vroom environment, then jump into some
-examples. If you haven't seen the setup code below yet, read through main.vroom
-briefly.
+examples.
 
   :source $VROOMDIR/setupvroom.vim
 

--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -4,10 +4,7 @@ We'll set up codefmt and configure the vroom environment, then jump into some
 examples. If you haven't seen the setup code below yet, read through main.vroom
 briefly.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
   :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 

--- a/vroom/autopep8.vroom
+++ b/vroom/autopep8.vroom
@@ -4,10 +4,7 @@ We'll set up codefmt and configure the vroom environment, then jump into some
 examples. If you haven't seen the setup code below yet, read through main.vroom
 briefly.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
   :let g:repeat_calls = []
   :function FakeRepeat(...)<CR>

--- a/vroom/autopep8.vroom
+++ b/vroom/autopep8.vroom
@@ -1,8 +1,8 @@
 The built-in autopep8 formatter knows how to format python code.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
 
 We'll set up codefmt and configure the vroom environment, then jump into some
-examples. If you haven't seen the setup code below yet, read through main.vroom
-briefly.
+examples.
 
   :source $VROOMDIR/setupvroom.vim
 

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -1,5 +1,6 @@
 The built-in clang-format formatter knows how to format code for C/C++ and many
 C-like languages.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
 
 We'll set up codefmt and configure the vroom environment, then jump into some
 examples. If you haven't seen the setup code below yet, read through main.vroom

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -5,10 +5,7 @@ We'll set up codefmt and configure the vroom environment, then jump into some
 examples. If you haven't seen the setup code below yet, read through main.vroom
 briefly.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
   :let g:repeat_calls = []
   :function FakeRepeat(...)<CR>

--- a/vroom/extensions.vroom
+++ b/vroom/extensions.vroom
@@ -3,10 +3,7 @@ registry.
 
 First, we need to set up the vroom environment and install codefmt.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
 Formatters are described as a dict that has certain fields defined, as
 described in the codefmt docs.

--- a/vroom/extensions.vroom
+++ b/vroom/extensions.vroom
@@ -1,5 +1,6 @@
 Codefmt can be extended to support new formatters, using maktaba's extension
 registry.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
 
 First, we need to set up the vroom environment and install codefmt.
 

--- a/vroom/gofmt.vroom
+++ b/vroom/gofmt.vroom
@@ -4,10 +4,7 @@ We'll set up codefmt and configure the vroom environment, then jump into some
 examples. If you haven't seen the setup code below yet, read through main.vroom
 briefly.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
   :let g:repeat_calls = []
   :function FakeRepeat(...)<CR>

--- a/vroom/gofmt.vroom
+++ b/vroom/gofmt.vroom
@@ -1,8 +1,8 @@
 The built-in gofmt formatter knows how to format go code.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
 
 We'll set up codefmt and configure the vroom environment, then jump into some
-examples. If you haven't seen the setup code below yet, read through main.vroom
-briefly.
+examples.
 
   :source $VROOMDIR/setupvroom.vim
 

--- a/vroom/jsbeautify.vroom
+++ b/vroom/jsbeautify.vroom
@@ -1,9 +1,9 @@
 The built-in js-beautify formatter knows how to format javascript, json, html
 and css code.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
 
 We'll set up codefmt and configure the vroom environment, then jump into some
-examples. If you haven't seen the setup code below yet, read through main.vroom
-briefly.
+examples.
 
   :source $VROOMDIR/setupvroom.vim
 

--- a/vroom/jsbeautify.vroom
+++ b/vroom/jsbeautify.vroom
@@ -5,10 +5,7 @@ We'll set up codefmt and configure the vroom environment, then jump into some
 examples. If you haven't seen the setup code below yet, read through main.vroom
 briefly.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
   :let g:repeat_calls = []
   :function FakeRepeat(...)<CR>

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -16,13 +16,11 @@ directory cover various topics of codefmt usage:
 * extensions.vroom - Adding additional formatters for codefmt to use
 
 In order for these tests to work, maktaba MUST be in the same parent directory
-as codefmt. Given that that's the case, all we have to do is source the codefmt
-bootstrap file.
+as codefmt. Given that that's the case, all we have to do is source the
+setupvroom.vim file, which bootstraps the codefmt plugin and configures it to
+work properly under vroom.
 
-  :set nocompatible
-  :let g:repo = fnamemodify($VROOMFILE, ':p:h:h')
-  :execute 'source' g:repo . '/bootstrap.vim'
-  :call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')
+  :source $VROOMDIR/setupvroom.vim
 
 
 It integrates with vim-repeat if available for improved repeating support. We'll

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -1,0 +1,23 @@
+" Codefmt does not support compatible mode.
+set nocompatible
+
+" Install the codefmt plugin.
+let s:repo = expand('<sfile>:p:h:h')
+execute 'source' s:repo . '/bootstrap.vim'
+
+" Install Glaive from local dir.
+let s:search_dir = fnamemodify(s:repo, ':h')
+for s:plugin_dirname in ['glaive', 'vim-glaive']
+  let s:bootstrap_path =
+      \ maktaba#path#Join([s:search_dir, s:plugin_dirname, 'bootstrap.vim'])
+  if filereadable(s:bootstrap_path)
+    execute 'source' s:bootstrap_path
+    break
+  endif
+endfor
+
+" Force
+call maktaba#plugin#Get('codefmt').Load()
+
+" Support vroom's fake shell executable and don't try to override it to sh.
+call maktaba#syscall#SetUsableShellRegex('\v<shell\.vroomfaker$')

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -1,3 +1,20 @@
+" Copyright 2015 Google Inc. All rights reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+" This file is used from vroom scripts to bootstrap the codefmt plugin and
+" configure it to work properly under vroom.
+
 " Codefmt does not support compatible mode.
 set nocompatible
 
@@ -16,7 +33,8 @@ for s:plugin_dirname in ['glaive', 'vim-glaive']
   endif
 endfor
 
-" Force
+" Force plugin/ files to load since vroom installs the plugin after
+" |load-plugins| time.
 call maktaba#plugin#Get('codefmt').Load()
 
 " Support vroom's fake shell executable and don't try to override it to sh.


### PR DESCRIPTION
Moves testing setup code out of bootstrap.vim (because it's only supposed to get the plugin installed, not try to install glaive from custom paths, etc.). Also moves the maktaba version check so it will trigger for all users and not just any users that source bootstrap.vim.

Fixes #39.