### PR TITLE
Fix a trivial documentation typo.

### DIFF
--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -14,8 +14,9 @@
 
 ""
 " @section Formatters, formatters
-" This plugin has two built-in formatters: clang-format and gofmt. More
-" formatters can be registered by other plugins that integrate with codefmt.
+" This plugin has three built-in formatters: clang-format, gofmt, and autopep8.
+" More formatters can be registered by other plugins that integrate with
+" codefmt.
 "
 " @subsection Default formatters
 " Codefmt will automatically use a default formatter for certain filetypes if

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -76,8 +76,9 @@ formatting.
 ==============================================================================
 FORMATTERS                                                *codefmt-formatters*
 
-This plugin has two built-in formatters: clang-format and gofmt. More
-formatters can be registered by other plugins that integrate with codefmt.
+This plugin has three built-in formatters: clang-format, gofmt, and autopep8.
+More formatters can be registered by other plugins that integrate with
+codefmt.
 
 DEFAULT FORMATTERS
 Codefmt will automatically use a default formatter for certain filetypes if


### PR DESCRIPTION
Our two formatters are clang-format and gofmt... and autopep8.