### PR TITLE
AutoFormatBuffer no longer sets repeat

### DIFF
--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -428,7 +428,7 @@ endfunction
 
 ""
 " Applies [formatter] to the current buffer.
-function! codefmt#FormatBuffer(...) abort
+function! codefmt#FormatBuffer(repeat, ...) abort
   let l:formatter = a:0 >= 1 ? s:GetFormatter(a:1) : s:GetFormatter()
   if l:formatter is# 0
     return
@@ -446,8 +446,10 @@ function! codefmt#FormatBuffer(...) abort
     call maktaba#error#Shout('Error formatting file: %s', v:exception)
   endtry
 
-  let l:cmd = ":FormatCode " . l:formatter.name . "\<CR>"
-  silent! call repeat#set(l:cmd)
+  if a:repeat
+    let l:cmd = ":FormatCode " . l:formatter.name . "\<CR>"
+    silent! call repeat#set(l:cmd)
+  endif
 endfunction
 
 ""
@@ -476,6 +478,7 @@ function! codefmt#FormatLines(startline, endline, ...) abort
   catch
     call maktaba#error#Shout('Error formatting file: %s', v:exception)
   endtry
+
   let l:cmd = ":FormatLines " . l:formatter.name . "\<CR>"
   let l:lines_formatted = a:endline - a:startline + 1
   silent! call repeat#set(l:cmd, l:lines_formatted)

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -428,7 +428,7 @@ endfunction
 
 ""
 " Applies [formatter] to the current buffer.
-function! codefmt#FormatBuffer(repeat, ...) abort
+function! codefmt#FormatBuffer(...) abort
   let l:formatter = a:0 >= 1 ? s:GetFormatter(a:1) : s:GetFormatter()
   if l:formatter is# 0
     return
@@ -445,11 +445,6 @@ function! codefmt#FormatBuffer(repeat, ...) abort
   catch
     call maktaba#error#Shout('Error formatting file: %s', v:exception)
   endtry
-
-  if a:repeat
-    let l:cmd = ":FormatCode " . l:formatter.name . "\<CR>"
-    silent! call repeat#set(l:cmd)
-  endif
 endfunction
 
 ""
@@ -478,10 +473,6 @@ function! codefmt#FormatLines(startline, endline, ...) abort
   catch
     call maktaba#error#Shout('Error formatting file: %s', v:exception)
   endtry
-
-  let l:cmd = ":FormatLines " . l:formatter.name . "\<CR>"
-  let l:lines_formatted = a:endline - a:startline + 1
-  silent! call repeat#set(l:cmd, l:lines_formatted)
 endfunction
 
 ""

--- a/plugin/autocmds.vim
+++ b/plugin/autocmds.vim
@@ -32,6 +32,6 @@ augroup END
 
 function! s:FmtIfAutoEnabled() abort
   if get(b:, 'codefmt_auto_format_buffer')
-    call codefmt#FormatBuffer(0)
+    call codefmt#FormatBuffer()
   endif
 endfunction

--- a/plugin/autocmds.vim
+++ b/plugin/autocmds.vim
@@ -32,6 +32,6 @@ augroup END
 
 function! s:FmtIfAutoEnabled() abort
   if get(b:, 'codefmt_auto_format_buffer')
-    call codefmt#FormatBuffer()
+    call codefmt#FormatBuffer(0)
   endif
 endfunction

--- a/plugin/commands.vim
+++ b/plugin/commands.vim
@@ -39,7 +39,7 @@ command -nargs=? -range -complete=custom,codefmt#GetSupportedFormatters
 " See @section(formatters) for list of valid formatters.
 " @default formatter=the default formatter associated with the current buffer
 command -nargs=? -complete=custom,codefmt#GetSupportedFormatters
-    \ FormatCode call codefmt#FormatBuffer(<f-args>)
+    \ FormatCode call codefmt#FormatBuffer(1, <f-args>)
 
 ""
 " Enables format on save for this buffer using [formatter]. Also configures

--- a/plugin/commands.vim
+++ b/plugin/commands.vim
@@ -27,19 +27,30 @@ function! s:AutoFormatBuffer(...) abort
   let b:codefmt_auto_format_buffer = 1
 endfunction
 
+function! s:FormatLinesAndSetRepeat(startline, endline, ...) abort
+  call call('codefmt#FormatLines', [a:startline, a:endline] + a:000)
+  let l:cmd = ":FormatLines " . join(a:000, ' ') . "\<CR>"
+  silent! call repeat#set(l:cmd)
+endfunction
+
+function! s:FormatBufferAndSetRepeat(...) abort
+  call call('codefmt#FormatBuffer', a:000)
+  let l:cmd = ":FormatCode " . join(a:000, ' ') . "\<CR>"
+  silent! call repeat#set(l:cmd)
+endfunction
 
 ""
 " Format the current line or range using [formatter].
 " @default formatter=the default formatter associated with the current buffer
 command -nargs=? -range -complete=custom,codefmt#GetSupportedFormatters
-    \ FormatLines call codefmt#FormatLines(<line1>, <line2>, <f-args>)
+    \ FormatLines call s:FormatLinesAndSetRepeat(<line1>, <line2>, <f-args>)
 
 ""
 " Format the whole buffer using [formatter].
 " See @section(formatters) for list of valid formatters.
 " @default formatter=the default formatter associated with the current buffer
 command -nargs=? -complete=custom,codefmt#GetSupportedFormatters
-    \ FormatCode call codefmt#FormatBuffer(1, <f-args>)
+    \ FormatCode call s:FormatBufferAndSetRepeat(<f-args>)
 
 ""
 " Enables format on save for this buffer using [formatter]. Also configures


### PR DESCRIPTION
Say you have :AutoFormatBuffer enabled and you're editing file. Then you change a line, save it, because why not. You then go to another line and hit . to replay that change, it reformats the code.
In my opinion it's pretty clear that the behavior is weird in this situation. I honestly don't see when having code formatting be something that is repeatable via . is useful but I'd be interested to hear the reasoning behind it. [#45]

This fixes it.