### PR TITLE
Add cursor support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 env:
   matrix:
     # This Maktaba version should match the minimum required in instant/flags.vim.
-    - CI_TARGET=vim MAKTABA_VERSION=1.9.0
+    - CI_TARGET=vim MAKTABA_VERSION=1.10.0
     - CI_TARGET=vim MAKTABA_VERSION=master
     - CI_TARGET=neovim MAKTABA_VERSION=master
 before_script:

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -189,13 +189,8 @@ function! codefmt#GetClangFormatFormatter() abort
   endfunction
 
   function l:formatter.AppliesToBuffer() abort
-    if &filetype is# 'c' || &filetype is# 'cpp' ||
+    return &filetype is# 'c' || &filetype is# 'cpp' ||
          \ &filetype is# 'proto' || &filetype is# 'javascript'
-      return 1
-    endif
-    " Version 3.6 adds support for java
-    " http://llvm.org/releases/3.6.0/tools/clang/docs/ReleaseNotes.html
-    return &filetype is# 'java' && s:ClangFormatHasAtLeastVersion([3, 6])
   endfunction:
 
   ""

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -84,11 +84,11 @@ function! codefmt#EnsureFormatter(formatter) abort
   " Throw BadValue if the wrong number of format functions are provided.
   let l:available_format_functions = ['Format', 'FormatRange', 'FormatRanges']
   let l:format_functions = filter(copy(l:available_format_functions),
-        \ 'has_key(a:formatter, v:val)')
+      \ 'has_key(a:formatter, v:val)')
   if empty(l:format_functions)
     throw maktaba#error#BadValue('Formatter ' . a:formatter.name .
-          \ ' has no format functions.  It must have at least one of ' .
-          \ join(l:available_format_functions, ', '))
+        \ ' has no format functions.  It must have at least one of ' .
+        \ join(l:available_format_functions, ', '))
   endif
 
   " TODO(dbarnett): Check types.
@@ -120,8 +120,7 @@ function! codefmt#GetJsBeautifyFormatter() abort
   " {endline}.
   " @throws ShellError
   function l:formatter.FormatRange(startline, endline) abort
-    let l:cmd = [ s:plugin.Flag('js_beautify_executable'),
-                \'-f', '-' ]
+    let l:cmd = [s:plugin.Flag('js_beautify_executable'), '-f', '-']
     if &filetype != ""
       let l:cmd = l:cmd + ['--type', &filetype]
     endif
@@ -190,8 +189,8 @@ function! codefmt#GetClangFormatFormatter() abort
 
   function l:formatter.AppliesToBuffer() abort
     return &filetype is# 'c' || &filetype is# 'cpp' ||
-         \ &filetype is# 'proto' || &filetype is# 'javascript'
-  endfunction:
+        \ &filetype is# 'proto' || &filetype is# 'javascript'
+  endfunction
 
   ""
   " Reformat buffer with clang-format, only targeting [ranges] if given.
@@ -244,11 +243,11 @@ function! codefmt#GetClangFormatFormatter() abort
       try
         let l:clang_format_output_json = maktaba#json#Parse(l:formatted[0])
         let l:new_cursor_pos =
-              \ maktaba#ensure#IsNumber(l:clang_format_output_json.Cursor) + 1
+            \ maktaba#ensure#IsNumber(l:clang_format_output_json.Cursor) + 1
         execute 'goto' l:new_cursor_pos
       catch
         call maktaba#error#Warn('Unable to parse clang-format cursor pos: %s',
-              \ v:exception)
+            \ v:exception)
       endtry
     endif
   endfunction
@@ -369,12 +368,10 @@ function! codefmt#GetAutopep8Formatter() abort
     let l:lines = getline(1, line('$'))
 
     if s:autopep8_supports_range
-      let l:cmd = [ l:executable,
-                  \ '--range', ''.a:startline, ''.a:endline,
-                  \ '-' ]
+      let l:cmd = [l:executable, '--range', ''.a:startline, ''.a:endline, '-']
       let l:input = join(l:lines, "\n")
     else
-      let l:cmd = [ l:executable, '-' ]
+      let l:cmd = [l:executable, '-']
       " Hack range formatting by formatting range individually, ignoring context.
       let l:input = join(l:lines[a:startline - 1 : a:endline - 1], "\n")
     endif
@@ -416,7 +413,7 @@ function! codefmt#IsFormatterAvailable() abort
   let l:formatters = copy(s:registry.GetExtensions())
   let l:is_available = 'v:val.AppliesToBuffer() && s:IsAvailable(v:val)'
   return !empty(filter(l:formatters, l:is_available)) ||
-        \ !empty(get(b:, 'codefmt_formatter'))
+      \ !empty(get(b:, 'codefmt_formatter'))
 endfunction
 
 function! s:GetSetupInstructions(formatter) abort
@@ -462,13 +459,13 @@ function! s:GetFormatter(...) abort
       " Check if we have formatters that are not available for some reason.
       " Report a better error message in that case.
       let l:unavailable_formatters = filter(
-            \ copy(l:formatters), 'v:val.AppliesToBuffer()')
+          \ copy(l:formatters), 'v:val.AppliesToBuffer()')
       if !empty(l:unavailable_formatters)
         let l:error = join(map(copy(l:unavailable_formatters),
-              \ 's:GetSetupInstructions(v:val)'), "\n")
+            \ 's:GetSetupInstructions(v:val)'), "\n")
       else
         let l:error = 'Not available. codefmt doesn''t have a default ' .
-              \ 'formatter for this buffer.'
+            \ 'formatter for this buffer.'
       endif
       call maktaba#error#Shout(l:error)
       return

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -234,7 +234,7 @@ function! codefmt#GetClangFormatFormatter() abort
     let l:supports_cursor = s:ClangFormatHasAtLeastVersion([3, 4])
     if l:supports_cursor
       " line2byte counts bytes from 1, and col counts from 1, so -2 
-      let l:cursor_pos = line2byte(line(".")) + col(".") - 2
+      let l:cursor_pos = line2byte(line('.')) + col('.') - 2
       let l:cmd += ['-cursor', string(l:cursor_pos)]
     endif
 
@@ -250,7 +250,7 @@ function! codefmt#GetClangFormatFormatter() abort
         let l:clang_format_output_json = maktaba#json#Parse(l:formatted[0])
         let l:new_cursor_pos =
               \ maktaba#ensure#IsNumber(l:clang_format_output_json.Cursor) + 1
-        exec "goto " . l:new_cursor_pos
+        execute 'goto' l:new_cursor_pos
       catch
         call maktaba#error#Warn('Unable to parse clang-format cursor pos: %s',
               \ v:exception)

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -168,6 +168,14 @@ endfunction
 
 ""
 " @private
+" Invalidates the cached clang-format version.
+function! codefmt#InvalidateClangFormatVersion() abort
+  unlet! s:clang_format_version
+endfunction
+
+
+""
+" @private
 " Formatter: clang-format
 function! codefmt#GetClangFormatFormatter() abort
   let l:formatter = {
@@ -549,8 +557,7 @@ endfunction
 
 ""
 " @private
-" Invalidates the cached autopep8 version detection for testing, forcing the
-" autopep8 formatter to check for it again on the next invocation.
+" Invalidates the cached autopep8 version detection info.
 function! codefmt#InvalidateAutopep8Version() abort
   unlet! s:autopep8_supports_range
 endfunction

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -33,8 +33,8 @@ endif
 
 
 " Shout if maktaba is too old. Done here to ensure it's always triggered.
-if !maktaba#IsAtLeastVersion('1.9.0')
-  call maktaba#error#Shout('Codefmt requires maktaba version 1.9.0.')
+if !maktaba#IsAtLeastVersion('1.10.0')
+  call maktaba#error#Shout('Codefmt requires maktaba version 1.10.0.')
   call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
   call maktaba#error#Shout('Please update your maktaba install.')
 endif
@@ -51,6 +51,10 @@ call s:plugin.flags.autopep8_executable.AddCallback(
 ""
 " The path to the clang-format executable.
 call s:plugin.Flag('clang_format_executable', 'clang-format')
+" Invalidate cache of detected clang-format version when this is changed, regardless
+" of {value} arg.
+call s:plugin.flags.clang_format_executable.AddCallback(
+    \ maktaba#function#FromExpr('codefmt#InvalidateClangFormatVersion()'), 0)
 
 ""
 " Formatting style for clang-format to use. Either a string or callable that

--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -31,6 +31,8 @@ or whatever conditions you want to trigger on.
   |i);}
 
   :doautocmd BufWritePre
+  ! clang-format --version .*
+  $ clang-format version 3.3.0 (tags/testing)
   ! clang-format .*
   $ void f() {
   $   int i;

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -137,14 +137,14 @@ It can format specific line ranges of code using :FormatLines.
 It will keep the cursor in the correct position when formatting code (assuming
 that clang-format has a version >= 3.4).
 
-  :Glaive codefmt clang_format_executable='clang-format-3.2'
+  :Glaive codefmt clang_format_executable='clang-format-3.3'
   @clear
   % int f() { int i = 1; return 1234567890; }
 
   :FormatCode clang-format
-  ! clang-format-3.2 --version .*
-  $ clang-format version 3.2.0 (tags/testing)
-  ! clang-format-3.2 -style file .*2>.*
+  ! clang-format-3.3 --version .*
+  $ clang-format version 3.3.0 (tags/testing)
+  ! clang-format-3.3 -style file .*2>.*
   $ int f() {
   $   int i = 1;
   $   return 1234567890;

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -76,8 +76,7 @@ You can format any buffer with clang-format specifying the formatter explicitly.
   @end
 
 Several filetypes will use the clang-format formatter by default: c, cpp,
-javascript, and proto.  If the version of clang-format is >= 3.6, then it will
-also format java files.
+javascript, and proto.
 
   @clear
   % f();
@@ -95,12 +94,6 @@ also format java files.
   $ f();
 
   :set filetype=proto
-  :FormatCode
-  ! clang-format .*
-  $ { "Cursor": 0 }
-  $ f();
-
-  :set filetype=java
   :FormatCode
   ! clang-format .*
   $ { "Cursor": 0 }

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -18,21 +18,40 @@ briefly.
 
 
 The clang-format formatter expects the clang-format executable to be installed
-on your system (version 3.4 or newer).
+on your system.
 
   % f();
   :FormatCode clang-format
+  ! clang-format --version .*
+  $ clang-format version 3.7.0 (tags/testing)
   ! clang-format .*
+  $ { "Cursor": 0 }
   $ f();
 
-The name or path of the clang-format executable can be configured via the
-clang_format_executable flag if the default of "clang-format" doesn't work.
+Notice the "clang-format --version" syscall. The clang-format formatter checks
+the version of the clang-format executable to detect what features it supports.
+It caches the result, so it only does this once per vim session.  We'll take a
+closer look at that below.
 
-  :Glaive codefmt clang_format_executable='clang-format-3.4'
+Any time this flag is changed, the cached version is invalidated and checked
+fresh on the next format invocation.  The name or path of the clang-format
+executable can be configured via the clang_format_executable flag if the
+default of "clang-format" doesn't work.
+
+  :Glaive codefmt clang_format_executable='clang-format-3.9'
   :FormatCode clang-format
-  ! clang-format-3.4 .*
+  ! clang-format-3.9 --version .*
+  $ clang-format version 3.9.0 (tags/testing)
+  ! clang-format-3.9 .*
+  $ { "Cursor": 0 }
   $ f();
   :Glaive codefmt clang_format_executable='clang-format'
+  :FormatCode clang-format
+  ! clang-format --version .*
+  $ clang-format version 3.9.0 (tags/testing)
+  ! clang-format .*
+  $ { "Cursor": 0 }
+  $ f();
 
 
 You can format any buffer with clang-format specifying the formatter explicitly.
@@ -43,6 +62,7 @@ You can format any buffer with clang-format specifying the formatter explicitly.
 
   :FormatCode clang-format
   ! clang-format -style file .*2>.*
+  $ { "Cursor": 0 }
   $ void f() {
   $   int i;
   $   SomeFunction(parameter,  // comment
@@ -55,8 +75,9 @@ You can format any buffer with clang-format specifying the formatter explicitly.
   }
   @end
 
-Several filetypes will use the clang-format formatter by default:
-c, cpp, javascript, and proto.
+Several filetypes will use the clang-format formatter by default: c, cpp,
+javascript, and proto.  If the version of clang-format is >= 3.6, then it will
+also format java files.
 
   @clear
   % f();
@@ -64,16 +85,25 @@ c, cpp, javascript, and proto.
   :set filetype=cpp
   :FormatCode
   ! clang-format .*
+  $ { "Cursor": 0 }
   $ f();
 
   :set filetype=javascript
   :FormatCode
   ! clang-format .*
+  $ { "Cursor": 0 }
   $ f();
 
   :set filetype=proto
   :FormatCode
   ! clang-format .*
+  $ { "Cursor": 0 }
+  $ f();
+
+  :set filetype=java
+  :FormatCode
+  ! clang-format .*
+  $ { "Cursor": 0 }
   $ f();
 
   :set filetype=
@@ -89,6 +119,7 @@ It can format specific line ranges of code using :FormatLines.
 
   :3,4FormatLines clang-format
   ! clang-format -style file -lines 3:4 .*2>.*
+  $ { "Cursor": 0 }
   $ void f() {
   $   int i = 2+2;
   $   int i = 3 + 3;
@@ -100,6 +131,52 @@ It can format specific line ranges of code using :FormatLines.
     int i = 4 + 4;
   }
   @end
+
+
+
+It will keep the cursor in the correct position when formatting code (assuming
+that clang-format has a version >= 3.4).
+
+  :Glaive codefmt clang_format_executable='clang-format-3.2'
+  @clear
+  % int f() { int i = 1; return 1234567890; }
+
+  :FormatCode clang-format
+  ! clang-format-3.2 --version .*
+  $ clang-format version 3.2.0 (tags/testing)
+  ! clang-format-3.2 -style file .*2>.*
+  $ int f() {
+  $   int i = 1;
+  $   return 1234567890;
+  $ }
+  int f() {
+    int i = 1;
+    return 1234567890;
+  }
+  @end
+  :Glaive codefmt clang_format_executable='clang-format'
+  @clear
+  % int f() { int i = 1; return 1234567890; }
+
+  :goto 33
+  :echomsg getline('.')[col('.')-1]
+  ~ 5
+  :FormatCode clang-format
+  ! clang-format --version .*
+  $ clang-format version 3.7.0 (tags/testing)
+  ! clang-format -style file .* -cursor 32 .*2>.*
+  $ { "Cursor": 36 }
+  $ int f() {
+  $   int i = 1;
+  $   return 1234567890;
+  $ }
+  int f() {
+    int i = 1;
+    return 1234567890;
+  }
+  @end
+  :echomsg getline('.')[col('.')-1]
+  ~ 5
 
 
 
@@ -115,6 +192,7 @@ a string value to use everywhere...
   % f();
   :FormatCode clang-format
   ! clang-format -style WebKit .*2>.*
+  $ { "Cursor": 0 }
   $ f();
 
 ...or a callable that takes no arguments and returns a string style name for the
@@ -131,11 +209,13 @@ current buffer.
   :silent file /foo/WebKit/foo.cc
   :FormatCode clang-format
   ! clang-format -style WebKit -assume-filename .*foo.cc .*2>.*
+  $ { "Cursor": 0 }
   $ f();
 
   :silent file /foo/foo.cc
   :FormatCode clang-format
   ! clang-format -style file -assume-filename .*foo.cc .*2>.*
+  $ { "Cursor": 0 }
   $ f();
 
   :Glaive codefmt clang_format_style='file'

--- a/vroom/jsbeautify.vroom
+++ b/vroom/jsbeautify.vroom
@@ -63,6 +63,8 @@ javascript, json, html and css.
 
   :set filetype=javascript
   :FormatCode
+  ! clang-format --version .*
+  $ clang-format version 3.3.0 (tags/testing)
   ! clang-format .*
   $ f();
 

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -44,6 +44,8 @@ This plugin defines a :FormatCode command that can be used to reformat buffers.
   |i);}
 
   :FormatCode clang-format
+  ! clang-format --version .*
+  $ clang-format version 3.3.0 (tags/testing)
   ! clang-format .*
   $ void f() {
   $   int i;


### PR DESCRIPTION
Adds cursor support and java support with conditional version checking for both.  I have not regenerated the documentation, because my experiments with vimdoc failed.