### PR TITLE
Fixes #61: Catch yapf errors instead of overwriting file

### DIFF
--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -437,15 +437,14 @@ function! codefmt#GetYAPFFormatter() abort
     let l:cmd = [l:executable, '--lines=' . a:startline . '-' . a:endline]
     let l:input = join(l:lines, "\n")
 
-    try
-      let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call()
-      let l:formatted = split(l:result.stdout, "\n")
+    let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call(0)
+    if v:shell_error == 1 " Indicates an error with parsing
+      call maktaba#error#Shout('Error formatting file: %s', l:result.stderr)
+      return
+    endif
+    let l:formatted = split(l:result.stdout, "\n")
 
-      call maktaba#buffer#Overwrite(1, line('$'), l:formatted)
-    catch /ERROR(ShellError):/
-      call maktaba#error#Shout('Error formatting file: %s', v:exception)
-    endtry
-
+    call maktaba#buffer#Overwrite(1, line('$'), l:formatted)
   endfunction
 
   return l:formatter

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -441,9 +441,7 @@ function! codefmt#GetYAPFFormatter() abort
       let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call()
       let l:formatted = split(l:result.stdout, "\n")
 
-      let l:full_formatted = l:formatted
-
-      call maktaba#buffer#Overwrite(1, line('$'), l:full_formatted)
+      call maktaba#buffer#Overwrite(1, line('$'), l:formatted)
     catch /ERROR(ShellError):/
       call maktaba#error#Shout('Error formatting file: %s', v:exception)
     endtry

--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -437,12 +437,17 @@ function! codefmt#GetYAPFFormatter() abort
     let l:cmd = [l:executable, '--lines=' . a:startline . '-' . a:endline]
     let l:input = join(l:lines, "\n")
 
-    let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call(0)
-    let l:formatted = split(l:result.stdout, "\n")
+    try
+      let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call()
+      let l:formatted = split(l:result.stdout, "\n")
 
-    let l:full_formatted = l:formatted
+      let l:full_formatted = l:formatted
 
-    call maktaba#buffer#Overwrite(1, line('$'), l:full_formatted)
+      call maktaba#buffer#Overwrite(1, line('$'), l:full_formatted)
+    catch /ERROR(ShellError):/
+      call maktaba#error#Shout('Error formatting file: %s', v:exception)
+    endtry
+
   endfunction
 
   return l:formatter


### PR DESCRIPTION
This isn't perfect, since it doesn't try to parse the yapf output, but it at least won't overwrite the file if there's an error.