### PR TITLE
Stop passing -sort-includes to clang-format

### DIFF
--- a/autoload/codefmt.vim
+++ b/autoload/codefmt.vim
@@ -237,12 +237,6 @@ function! codefmt#GetClangFormatFormatter() abort
       let l:cmd += ['-cursor', string(l:cursor_pos)]
     endif
 
-    " Version 3.8 added support for the -sort-includes option.
-    " http://llvm.org/viewvc/llvm-project?view=revision&revision=248367
-    if s:ClangFormatHasAtLeastVersion([3, 8])
-      let l:cmd += ['-sort-includes']
-    endif
-
     let l:input = join(getline(1, line('$')), "\n")
     let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call()
     let l:formatted = split(l:result.stdout, "\n")

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -180,60 +180,6 @@ that clang-format has a version >= 3.4).
 
 
 
-For clang-format versions 3.8 and above, it will sort #include lines (using the
--sort-includes option).
-
-  :Glaive codefmt clang_format_executable='clang-format-3.7'
-  @clear
-  % #include <stdlib.h><CR>
-  |#include <stdio.h><CR>
-  |int f() { int i = 1; return 1234567890; }
-
-  :FormatCode clang-format
-  ! clang-format-3.7 --version .*
-  $ clang-format version 3.7.0 (tags/testing)
-  ! clang-format-3.7 -style file -lines 1:3 -cursor \d+ 2>.*
-  $ { "Cursor": 0 }
-  $ #include <stdlib.h>
-  $ #include <stdio.h>
-  $ int f() {
-  $   int i = 1;
-  $   return 1234567890;
-  $ }
-  #include <stdlib.h>
-  #include <stdio.h>
-  int f() {
-    int i = 1;
-    return 1234567890;
-  }
-  @end
-  :Glaive codefmt clang_format_executable='clang-format'
-  @clear
-  % #include <stdlib.h><CR>
-  |#include <stdio.h><CR>
-  |int f() { int i = 1; return 1234567890; }
-
-  :FormatCode clang-format
-  ! clang-format --version .*
-  $ clang-format version 3.8.0 (tags/testing)
-  ! clang-format -style file .* -sort-includes .*2>.*
-  $ { "Cursor": 0 }
-  $ #include <stdio.h>
-  $ #include <stdlib.h>
-  $ int f() {
-  $   int i = 1;
-  $   return 1234567890;
-  $ }
-  #include <stdio.h>
-  #include <stdlib.h>
-  int f() {
-    int i = 1;
-    return 1234567890;
-  }
-  @end
-
-
-
 You might have wondered where the "-style file" above comes from. The
 clang-format tool accepts a "style" option to control the formatting style. By
 default, "file" is used to indicate that clang-format should respect


### PR DESCRIPTION
`-sort-includes` was added in LLVM r248367, and is enabled-by-default as of r253202, both of which will presumably be included in LLVM 3.8 (which hasn't yet been released).

Removing this flag allows `:FormatCode` to work with development clang-format versions in the range [r242222, r248367), which identify as 3.8.0 but don't support `-sort-includes`.

This effectively reverts cb42d28. Fixes #64.