### PR TITLE
Improve jsbeautify tests

### DIFF
--- a/vroom/jsbeautify.vroom
+++ b/vroom/jsbeautify.vroom
@@ -54,26 +54,34 @@ You can format any buffer with js-beautify specifying the formatter explicitly.
   }
   @end
 
-# @TODO: fix default formatter for javascript
 Several filetypes will use the js-beautify formatter by default:
 javascript, json, html and css.
+
+Note that javascript will currently be picked up by clang-format;
+here we specify js-beautify explicitly.
+# @TODO: fix default formatter for javascript
 
   @clear
   % f();
 
+  :set filetype=javascript
+  :FormatCode js-beautify
+  ! js-beautify -f - --type js 2>.*
+  $ f();
+
   :set filetype=json
   :FormatCode
-  ! js-beautify .*
+  ! js-beautify -f - --type js 2>.*
   $ f();
 
   :set filetype=html
   :FormatCode
-  ! js-beautify .*
+  ! js-beautify -f - --type html 2>.*
   $ f();
 
   :set filetype=css
   :FormatCode
-  ! js-beautify .*
+  ! js-beautify -f - --type css 2>.*
   $ f();
 
   :set filetype=


### PR DESCRIPTION
Prior to #96 (3dad76a and 8e54240), the js-beautify binary was invoked with the wrong --type argument.

This change verifies the js-beautify arguments for each of the supported filetypes (so that we can verify the fixes above), and also explains what's wrong with the javascript filetype support (it's picked up by clang-format instead).