### PR TITLE
If the buffer has a path, pass it to buildifier as `-path PATH`.

### DIFF
--- a/autoload/codefmt/buildifier.vim
+++ b/autoload/codefmt/buildifier.vim
@@ -39,7 +39,12 @@ function! codefmt#buildifier#GetFormatter() abort
   " @flag(buildifier)
   " @throws ShellError
   function l:formatter.Format() abort
-    let l:cmd = s:plugin.Flag('buildifier_executable')
+    let l:cmd = [ s:plugin.Flag('buildifier_executable') ]
+    let l:fname = expand('%:p')
+    if !empty(l:fname)
+      let l:cmd += ['-path', l:fname]
+    endif
+
     let l:input = join(getline(1, line('$')), "\n")
     try
       let l:result = maktaba#syscall#Create(l:cmd).WithStdin(l:input).Call()

--- a/vroom/buildifier.vroom
+++ b/vroom/buildifier.vroom
@@ -1,5 +1,6 @@
-The built-in buildifier formatter knows how to format Bazel BUILD files.  If you
-aren't familiar with basic codefmt usage yet, see main.vroom first.
+The built-in buildifier formatter knows how to format Bazel BUILD and .bzl
+files.  If you aren't familiar with basic codefmt usage yet, see main.vroom
+first.
 
 We'll set up codefmt and configure the vroom environment, then jump into some
 examples.
@@ -38,14 +39,17 @@ buildifier_executable flag if the default of "buildifier" doesn't work.
   $ )
   :Glaive codefmt buildifier_executable='buildifier'
 
-The bzl filetype will use the buildifier formatter by default.
+The bzl filetype will use the buildifier formatter by default. The path to the
+file being edited is passed to buildifier so that it can adjust to whether the
+file is a BUILD or .bzl file.
 
   @clear
   % foo_library(name = "foo", srcs = ["bar.js"],)
 
+  :silent file /foo/bar/BUILD
   :set filetype=bzl
   :FormatCode
-  ! buildifier .*
+  ! buildifier -path /foo/bar/BUILD .*
   $ foo_library(
   $     name = "foo",
   $     srcs = ["bar.js"],


### PR DESCRIPTION
Fixes #100.