### PR TITLE
Add support for an arbitrary clang_format command with arguments

### DIFF
--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -30,7 +30,8 @@ The path to the autopep8 executable.
 Default: 'autopep8' `
 
                                              *codefmt:clang_format_executable*
-The path to the clang-format executable.
+The path to the clang-format executable. String, list, or callable that takes
+no args and returns a string or a list.
 Default: 'clang-format' `
 
                                                   *codefmt:clang_format_style*


### PR DESCRIPTION
Solves #123 by applying handling of `clang_format_executable` similar to the existing handling of `google_java_executable`