### PR TITLE
fix: neovim vroom tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: generic
 env:
+  global:
+    - VROOM_VERSION=0.13.0
   matrix:
     # This Maktaba version should match the minimum required in instant/flags.vim.
-    - CI_TARGET=vim MAKTABA_VERSION=1.10.0
+    - CI_TARGET=vim MAKTABA_VERSION=1.12.0
     - CI_TARGET=vim MAKTABA_VERSION=master
+    - CI_TARGET=neovim MAKTABA_VERSION=1.12.0
     - CI_TARGET=neovim MAKTABA_VERSION=master
 before_script:
   - sudo apt-get update
@@ -13,11 +16,11 @@ before_script:
     elif [ $CI_TARGET = neovim ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64" &&
       wget https://bootstrap.pypa.io/get-pip.py &&
-      sudo python3 get-pip.py --allow-external sudo &&
+      sudo python3 get-pip.py &&
       sudo pip3 install neovim;
     fi
-  - wget https://github.com/google/vroom/releases/download/v0.12.0/vroom_0.12.0-1_all.deb
-  - sudo dpkg -i ./vroom_0.12.0-1_all.deb
+  - wget https://github.com/google/vroom/releases/download/v${VROOM_VERSION}/vroom_${VROOM_VERSION}-1_all.deb
+  - sudo dpkg -i ./vroom_${VROOM_VERSION}-1_all.deb
   - git clone -b ${MAKTABA_VERSION} https://github.com/google/vim-maktaba.git ../maktaba/
   - git clone https://github.com/google/vim-glaive.git ../glaive/
 services:
@@ -27,5 +30,3 @@ script:
   - vroom $VROOM_ARGS --crawl ./vroom/
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: CI_TARGET=neovim MAKTABA_VERSION=master

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -33,6 +33,9 @@ endif
 
 
 " Shout if maktaba is too old. Done here to ensure it's always triggered.
+" We need at least 1.12.0 so that maktaba#ensure#IsCallable works on Neovim and
+" recent Vim (newer than is actually in Travis/Xenial).
+" See https://github.com/google/vim-maktaba/issues/173
 if !maktaba#IsAtLeastVersion('1.12.0')
   call maktaba#error#Shout('Codefmt requires maktaba version 1.12.0.')
   call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -33,8 +33,8 @@ endif
 
 
 " Shout if maktaba is too old. Done here to ensure it's always triggered.
-if !maktaba#IsAtLeastVersion('1.10.0')
-  call maktaba#error#Shout('Codefmt requires maktaba version 1.10.0.')
+if !maktaba#IsAtLeastVersion('1.12.0')
+  call maktaba#error#Shout('Codefmt requires maktaba version 1.12.0.')
   call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
   call maktaba#error#Shout('Please update your maktaba install.')
 endif

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -18,6 +18,9 @@
 " Codefmt does not support compatible mode.
 set nocompatible
 
+" Set cmdheight to avoid "Hit ENTER to continue" without needing :silent
+set cmdheight=10
+
 " Install the codefmt plugin.
 let s:repo = expand('<sfile>:p:h:h')
 execute 'source' s:repo . '/bootstrap.vim'


### PR DESCRIPTION
Four problems that were preventing the vroom tests from running on
neovim:

- The vroom version was too old, see
  https://github.com/google/vroom/pull/104

- The maktaba version was too old, see
  https://github.com/google/vim-maktaba/issues/172. I considered
  constraining this to neovim but it applies to recent vim as well (the
  version of vim in travis/xenial is quite old) and the extra version
  checking seems pointless.

- The get-pip.py invocation was outdated.

- For some reason neovim pauses more often with "Hit ENTER" messages.
  Perhaps newer vim would too. In any case, increasing the cmdheight
  solves the problem without needing to sprinkle :silent everywhere.