### PR TITLE
feat(prettier): use npx for project-local prettier

### DIFF
--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -83,12 +83,13 @@ Default: 'shfmt' `
                                                     *codefmt:prettier_options*
 Command line arguments to feed prettier. Either a list or callable that takes
 no args and returns a list with command line arguments.
-Default: [ '--single-quote', '--trailing-comma=all', '--arrow-parens=always',
-  '--print-width=80'] `
+Default: [] `
 
                                                  *codefmt:prettier_executable*
-The path to the prettier executable.
-Default: 'prettier' `
+The path to the prettier executable. String, list, or callable that takes no
+args and returns a string or a list. The default uses npx if available, so
+that the repository-local prettier will have priority.
+Default: function('s:LookupPrettierExecutable') `
 
                                                      *codefmt:rustfmt_options*
 Command line arguments to feed rustfmt. Either a list or callable that takes

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -111,9 +111,7 @@ call s:plugin.Flag('shfmt_executable', 'shfmt')
 ""
 " Command line arguments to feed prettier. Either a list or callable that
 " takes no args and returns a list with command line arguments.
-call s:plugin.Flag('prettier_options', [
-    \ '--single-quote', '--trailing-comma=all',
-    \ '--arrow-parens=always', '--print-width=80'])
+call s:plugin.Flag('prettier_options', [])
 
 ""
 " The path to the prettier executable.

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -114,8 +114,21 @@ call s:plugin.Flag('shfmt_executable', 'shfmt')
 call s:plugin.Flag('prettier_options', [])
 
 ""
-" The path to the prettier executable.
-call s:plugin.Flag('prettier_executable', 'prettier')
+" @private
+function s:LookupPrettierExecutable() abort
+  return executable('npx') ? ['npx', '--no-install', 'prettier'] : 'prettier'
+endfunction
+
+""
+" The path to the prettier executable. String, list, or callable that
+" takes no args and returns a string or a list. The default uses npx if
+" available, so that the repository-local prettier will have priority.
+call s:plugin.Flag('prettier_executable', function('s:LookupPrettierExecutable'))
+
+" Invalidate cache of detected prettier availability whenever
+" prettier_executable changes.
+call s:plugin.flags.prettier_executable.AddCallback(
+    \ maktaba#function#FromExpr('codefmt#prettier#InvalidateIsAvailable()'), 0)
 
 ""
 " Command line arguments to feed rustfmt. Either a list or callable that

--- a/vroom/prettier.vroom
+++ b/vroom/prettier.vroom
@@ -14,12 +14,17 @@ examples.
 
   :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
 
+The default value of prettier_executable is a function that checks if npx is
+available. We need a deterministic result for these tests, so we'll replace that
+with a simple string.
+
+  :Glaive codefmt prettier_executable='prettier'
 
 The prettier formatter expects the prettier executable to be installed on your system.
 
   % function HelloWorld(){if(!greeting){return null};}
   :FormatCode prettier
-  ! prettier .*
+  ! cd .* prettier .*
   $ function HelloWorld() {
   $   if (!greeting) {
   $     return null;
@@ -31,7 +36,7 @@ prettier_executable flag if the default of "prettier" doesn't work.
 
   :Glaive codefmt prettier_executable='myprettier'
   :FormatCode prettier
-  ! myprettier .*
+  ! cd .* myprettier .*
   $ function HelloWorld() {
   $   if (!greeting) {
   $     return null;
@@ -46,7 +51,7 @@ You can format any buffer with prettier specifying the formatter explicitly.
   % function HelloWorld(){if(!greeting){return null};}
 
   :FormatCode prettier
-  ! prettier .*2>.*
+  ! cd .* prettier .*2>.*
   $ function HelloWorld() {
   $   if (!greeting) {
   $     return null;
@@ -65,7 +70,7 @@ Errors are reported using the quickfix list.
   % function foo() {
 
   :FormatCode prettier
-  ! prettier .*2> (.*)
+  ! cd .* prettier .*2> (.*)
   $ 2 (status)
   $ echo >\1 ' (command)
   |[error] stdin: SyntaxError: Unexpected token (2:1)\n
@@ -87,7 +92,7 @@ It can format specific line ranges of code using :FormatLines.
   |function Greet(){if(!greeting){return null};}
 
   :1,1FormatLines prettier
-  ! prettier .*--parser babylon --range-end 50.*2>.*
+  ! cd .* prettier .*--parser babylon --range-end 50.*2>.*
   $ function HelloWorld() {
   $   if (!greeting) {
   $     return null;


### PR DESCRIPTION
If npx is available, use it for running prettier. This will find a project-local prettier, if available, which allows everybody on the team to run the same version. Otherwise people have different prettier versions, and code formatting toggles back and forth between commits.

Since npx can't tell us if prettier is available, we check with `npx prettier --version` and cache the result.

Also, since by default npx will do a temporary install of things you try to run, we use the `--no-install` flag to avoid that. We only want npx to find what's already there.

Along the way, kill the opinionated prettier options that were in vim-codefmt, since they unhelpfully override local and project config files.