### PR TITLE
fix(zprint): don't cd unless dir exists

### DIFF
--- a/autoload/codefmt/zprint.vim
+++ b/autoload/codefmt/zprint.vim
@@ -57,9 +57,13 @@ function! codefmt#zprint#GetFormatter() abort
     let l:opts = codefmt#formatterhelpers#ResolveFlagToArray(
           \ 'zprint_options')
 
-    " Prepare the syscall, changing to the containing directory in case the user
-    " has configured {:search-config? true} in ~/.zprintrc
-    let l:cmd = maktaba#syscall#Create(l:exe + l:opts).WithCwd(expand('%:p:h'))
+    " Prepare the syscall
+    let l:syscall = maktaba#syscall#Create(l:exe + l:opts)
+    if isdirectory(expand('%:p:h'))
+      " Change to the containing directory in case the user has configured
+      " {:search-config? true} in ~/.zprintrc
+      let l:syscall = l:syscall.WithCwd(expand('%:p:h'))
+    endif
 
     " zprint does not support range formatting yet:
     " https://github.com/kkinnear/zprint/issues/122
@@ -68,7 +72,7 @@ function! codefmt#zprint#GetFormatter() abort
     call codefmt#formatterhelpers#AttemptFakeRangeFormatting(
         \ a:startline,
         \ a:endline,
-        \ l:cmd)
+        \ l:syscall)
   endfunction
 
   return l:formatter

--- a/vroom/zprint.vroom
+++ b/vroom/zprint.vroom
@@ -84,6 +84,16 @@ Zprint is the default formatter for the clojure file type, so calling
   ! cd .* zprint .*
   :set filetype&
 
+If the directory containing the file doesn't exist yet, then the plugin won't
+try to change directories:
+
+  :silent file /does-not-exist/x.clj
+  :set filetype=clojure
+  :FormatCode
+  ! zprint .*
+  :set filetype&
+  :0file
+
 The default setting of zprint_options propagates Vim's textwidth setting to
 zprint's command-line.
 


### PR DESCRIPTION
This avoids the syscall failing if the directory doesn't exist yet. It's
an unlikely scenario, but I managed to hit it, and it's annoying when
tooling breaks in unlikely scenarios...