### PR TITLE
fix(prettier): drop --stdin parameter

### DIFF
--- a/autoload/codefmt/prettier.vim
+++ b/autoload/codefmt/prettier.vim
@@ -65,7 +65,7 @@ function! codefmt#prettier#GetFormatter() abort
   " {endline}.
   function l:formatter.FormatRange(startline, endline) abort
     let l:cmd = codefmt#formatterhelpers#ResolveFlagToArray(
-          \ 'prettier_executable') + ['--stdin', '--no-color']
+          \ 'prettier_executable') + ['--no-color']
 
     " prettier is able to automatically choose the best parser if the filepath
     " is provided. Otherwise, fall back to the previous default: babylon.


### PR DESCRIPTION
This changed in Prettier 2.0, and apparently was never needed. See
https://prettier.io/blog/2020/03/21/2.0.0.html#remove---stdin-7668httpsgithubcomprettierprettierpull7668-by-thorn0httpsgithubcomthorn0