### PR TITLE
clang-format: work around vim/vim#5930 when positioning cursor

### DIFF
--- a/autoload/codefmt/clangformat.vim
+++ b/autoload/codefmt/clangformat.vim
@@ -58,10 +58,10 @@ endfunction
 " Inputs are 1-based (row, col) coordinates into lines.
 " Returns the corresponding zero-based offset into lines->join("\n")
 function! s:PositionToOffset(row, col, lines) abort
-  let l:offset = a:col - 1
+  let l:offset = a:col - 1 " 1-based to 0-based
   if a:row > 1
-    for l:line in a:lines[0 : a:row - 2]
-      let l:offset += len(l:line) + 1
+    for l:line in a:lines[0 : a:row - 2] " 1-based to 0-based, exclude current
+      let l:offset += len(l:line) + 1 " +1 for newline
     endfor
   endif
   return l:offset
@@ -74,14 +74,14 @@ function! s:OffsetToPosition(offset, lines) abort
   let l:lines_consumed = 0
   let l:chars_left = a:offset
   for l:line in a:lines
-    let l:line_len = len(l:line) + 1
+    let l:line_len = len(l:line) + 1 " +1 for newline
     if l:chars_left < l:line_len
       break
     endif
     let l:chars_left -= l:line_len
     let l:lines_consumed += 1
   endfor
-  return [l:lines_consumed + 1, l:chars_left + 1]
+  return [l:lines_consumed + 1, l:chars_left + 1] " 0-based to 1-based
 endfunction
 
 

--- a/autoload/codefmt/clangformat.vim
+++ b/autoload/codefmt/clangformat.vim
@@ -74,11 +74,11 @@ function! s:OffsetToPosition(offset, lines) abort
   let l:lines_consumed = 0
   let l:chars_left = a:offset
   for l:line in a:lines
-    let l:chars_after_next = l:chars_left - len(l:line) - 1
-    if l:chars_after_next < 0
+    let l:line_len = len(l:line) + 1
+    if l:chars_left < l:line_len
       break
     endif
-    let l:chars_left = l:chars_after_next
+    let l:chars_left -= l:line_len
     let l:lines_consumed += 1
   endfor
   return [l:lines_consumed + 1, l:chars_left + 1]

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -178,7 +178,33 @@ that clang-format has a version >= 3.4).
   :echomsg getline('.')[col('.')-1]
   ~ 5
 
+This should work when with textprops set in the file, despite various functions
+like line2byte() and :goto being buggy in that case.
+(See https://github.com/vim/vim/issues/5930 for bug details)
 
+  @clear
+  % int f()     {<CR>
+  |    int i=1;<CR>
+  |   return 1234567890; }<CR>
+  :call prop_type_add('keyword', {})
+  :call prop_add(1, 1, {'length': 3, 'type': 'keyword'})
+  :call cursor(2, 10)
+  :echomsg getline('.')[col('.')-1]
+  ~ =
+  :FormatCode clang-format
+  ! clang-format -style file .* -cursor 23 .*2>.*
+  $ { "Cursor": 18 }
+  $ int f() {
+  $   int i = 1;
+  $   return 1234567890;
+  $ }
+  int f() {
+    int i = 1;
+    return 1234567890;
+  }
+  @end
+  :echomsg getline('.')[col('.')-1]
+  ~ =
 
 You might have wondered where the "-style file" above comes from. The
 clang-format tool accepts a "style" option to control the formatting style. By


### PR DESCRIPTION
This bug (and a related predecessor) cause `:goto` and `line2bytes()`
to do the wrong thing when vim textprops are used.
This manifests as "cursor jumps around randomly after formatting" when using
plugins that use textprops for diagnostics, highlighting etc.

We happen to have all the code in an array when we need to do cursor coordinate
conversions, so we do those in vimscript instead of querying vim.

Without this patch, The newly added test fails on affected versions of vim
including both vim master and debian's 8.1.2269 (in different ways).

Vim bug tracker entry:
https://github.com/vim/vim/issues/5930
Similar workaround in first-party vim integration:
https://github.com/llvm/llvm-project/commit/591be7ec500c151d9232366042e21c74e006292c