### PR TITLE
associate arduino file-type with clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Want to just sit back and let autoformat happen automatically? Add this to your
 ```vim
 augroup autoformat_settings
   autocmd FileType bzl AutoFormatBuffer buildifier
-  autocmd FileType c,cpp,proto,javascript AutoFormatBuffer clang-format
+  autocmd FileType c,cpp,proto,javascript,arduino AutoFormatBuffer clang-format
   autocmd FileType dart AutoFormatBuffer dartfmt
   autocmd FileType go AutoFormatBuffer gofmt
   autocmd FileType gn AutoFormatBuffer gn

--- a/autoload/codefmt/clangformat.vim
+++ b/autoload/codefmt/clangformat.vim
@@ -81,7 +81,7 @@ function! codefmt#clangformat#GetFormatter() abort
     if &filetype is# 'c' || &filetype is# 'cpp' ||
         \ &filetype is# 'proto' || &filetype is# 'javascript' ||
         \ &filetype is# 'objc' || &filetype is# 'objcpp' ||
-        \ &filetype is# 'typescript'
+        \ &filetype is# 'typescript' || &filetype is# 'arduino'
       return 1
     endif
     " Version 3.6 adds support for java


### PR DESCRIPTION
Arduino (https://www.arduino.cc/) source files (.ino filename extension) are essentially a c++ files, but recognized as a separate file type by vim (for Arduino-specific syntax highlighting, I believe). 
Arduino IDE, which uses .ino files for user source code, provides for external editor support, which could be vim.
I found it helpful to associate arduino files with clang-format, which works well for me.