### PR TITLE
Fix default parser for Prettier (babylon -> babel)

### DIFF
--- a/autoload/codefmt/prettier.vim
+++ b/autoload/codefmt/prettier.vim
@@ -68,9 +68,9 @@ function! codefmt#prettier#GetFormatter() abort
           \ 'prettier_executable') + ['--no-color']
 
     " prettier is able to automatically choose the best parser if the filepath
-    " is provided. Otherwise, fall back to the previous default: babylon.
+    " is provided. Otherwise, fall back to the previous default: babel.
     if @% == ""
-      call extend(l:cmd, ['--parser', 'babylon'])
+      call extend(l:cmd, ['--parser', 'babel'])
     else
       call extend(l:cmd, ['--stdin-filepath', expand('%:p')])
     endif


### PR DESCRIPTION
Minor fix that only impacts unnamed buffers: `babylon` was deprecated in v1.16.0 (prettier/prettier#5647) and removed in v2.0.0 (prettier/prettier#7533).