### PR TITLE
clang-format: fix tests on old vim without textprop

### DIFF
--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -186,8 +186,10 @@ like line2byte() and :goto being buggy in that case.
   % int f()     {<CR>
   |    int i=1;<CR>
   |   return 1234567890; }<CR>
-  :call prop_type_add('keyword', {})
-  :call prop_add(1, 1, {'length': 3, 'type': 'keyword'})
+  :if has('textprop')
+  :  call prop_type_add('keyword', {})
+  :  call prop_add(1, 1, {'length': 3, 'type': 'keyword'})
+  :endif
   :call cursor(2, 10)
   :echomsg getline('.')[col('.')-1]
   ~ =


### PR DESCRIPTION
d8dd427b9edd0c71d9373eb2696730d45d5bad75 broke the CI: https://travis-ci.org/github/google/vim-codefmt/jobs/680186570.