### PR TITLE
Add support for arbitrary shfmt command with arguments

### DIFF
--- a/autoload/codefmt/shfmt.vim
+++ b/autoload/codefmt/shfmt.vim
@@ -26,7 +26,13 @@ function! codefmt#shfmt#GetFormatter() abort
           \ 'and configure the shfmt_executable flag'}
 
   function l:formatter.IsAvailable() abort
-    return executable(s:plugin.Flag('shfmt_executable'))
+    let l:cmd = codefmt#formatterhelpers#ResolveFlagToArray(
+          \ 'shfmt_executable')
+    if !empty(l:cmd) && executable(l:cmd[0])
+      return 1
+    else
+      return 0
+    endif
   endfunction
 
   function l:formatter.AppliesToBuffer() abort
@@ -48,7 +54,8 @@ function! codefmt#shfmt#GetFormatter() abort
           \ 'shfmt_options flag must be list or callable. Found %s',
           \ string(l:Shfmt_options))
     endif
-    let l:cmd = [ s:plugin.Flag('shfmt_executable') ] + l:shfmt_options
+    let l:cmd = codefmt#formatterhelpers#ResolveFlagToArray(
+          \ 'shfmt_executable') + l:shfmt_options
     try
       " Feature request for range formatting:
       " https://github.com/mvdan/sh/issues/333

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -82,7 +82,8 @@ Google's style. See https://github.com/mvdan/sh for details.
 Default: ['-i', '2', '-sr', '-ci'] `
 
                                                     *codefmt:shfmt_executable*
-The path to the shfmt executable.
+The path to the shfmt executable. String, list, or callable that takes no args
+and returns a string or a list.
 Default: 'shfmt' `
 
                                                     *codefmt:prettier_options*

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -109,7 +109,8 @@ call s:plugin.Flag('google_java_executable', 'google-java-format')
 call s:plugin.Flag('shfmt_options', ['-i', '2', '-sr', '-ci'])
 
 ""
-" The path to the shfmt executable.
+" The path to the shfmt executable. String, list, or callable that
+" takes no args and returns a string or a list.
 call s:plugin.Flag('shfmt_executable', 'shfmt')
 
 ""

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -52,7 +52,8 @@ call s:plugin.flags.autopep8_executable.AddCallback(
     \ maktaba#function#FromExpr('codefmt#autopep8#InvalidateVersion()'), 0)
 
 ""
-" The path to the clang-format executable.
+" The path to the clang-format executable. String, list, or callable that
+" takes no args and returns a string or a list.
 call s:plugin.Flag('clang_format_executable', 'clang-format')
 " Invalidate cache of detected clang-format version when this is changed, regardless
 " of {value} arg.


### PR DESCRIPTION
Make it possible to use complex shfmt commands, such as shfmt running in a docker container. Use the codefmt#formatterhelpers#ResolveFlagToArray approach seen in other formatters.

Similar to https://github.com/google/vim-codefmt/pull/124