### PR TITLE
Adjust vroom tests to work with --message-strictness=STRICT

### DIFF
--- a/vroom/autocmd.vroom
+++ b/vroom/autocmd.vroom
@@ -60,7 +60,7 @@ same formatter.
 You can disable it for the current buffer with :NoAutoFormatBuffer. After that,
 the buffer will go back to doing nothing special when you save.
 
-  :%delete
+  @clear
   :NoAutoFormatBuffer
   % void f() {int i; SomeFunction(parameter,// comment<CR>
   |i);}

--- a/vroom/buildifier.vroom
+++ b/vroom/buildifier.vroom
@@ -67,6 +67,7 @@ Errors are reported using the quickfix list.
   ! buildifier .*2> (.*)
   $ echo 'stdin:2:15: syntax error near ]' >\1 (command)
   $ 1 (status)
+  ~ (1 of 1): syntax error near ]
   #
   java_package(])
   @end
@@ -84,11 +85,12 @@ slightly different format, prefixed with the filename we passed.
   :set filetype=bzl
   % load()
 
-  > go
+  :call cursor(1, 1)
   :FormatCode
   ! buildifier .*2> (.*)
   $ echo '/foo/bar/BUILD:1:7: syntax error near )' >\1 (command)
   $ 1 (status)
+  ~ (1 of 1): syntax error near )
   load()
   @end
 
@@ -104,9 +106,11 @@ report one column past the actual error.)
 If there are no errors, then the quickfix list is (currently, see
 https://github.com/google/vim-codefmt/issues/58) left alone:
 
-  > godd
+  @clear
+  :silent file /foo/bar/BUILD
+  :set filetype=bzl
   % load('@io_bazel_rules_go//proto:def.bzl','go_proto_library')
-  > go
+  :call cursor(1, 1)
 
   :FormatCode
   ! buildifier -path /foo/bar/BUILD .*
@@ -116,4 +120,3 @@ https://github.com/google/vim-codefmt/issues/58) left alone:
   ~ 1,1
   :echomsg len(getqflist())
   ~ 1
-  :set filetype=

--- a/vroom/fish_indent.vroom
+++ b/vroom/fish_indent.vroom
@@ -79,7 +79,8 @@ Errors are reported.
   ! fish_indent .*2> (.*)
   $ echo test error >\1 (command)
   $ 1 (status)
-  ~ test error
+  ~ Error formatting file:* (glob)
+  ~ *test error* (glob)
   function f;
   @end
 

--- a/vroom/main.vroom
+++ b/vroom/main.vroom
@@ -95,15 +95,15 @@ the same number of lines again.
 
 
 
-Formatting doesn't move the cursor.
+Even when the text under the cursor moves, formatting preserves the literal
+cursor position (except in formatter implementations that can intelligently
+preserve logical position; see examples in vroom/clangformat-cursor.vroom).
 
   % void f() {int i;<CR>
   |SomeFunction();<CR>
   |}
 
-  > 1G/Fun<CR>
-  :echomsg line('.') . ',' . col('.')
-  ~ 2,5
+  :call cursor(2, 5)
   :FormatCode clang-format
   ! clang-format .*
   $ void f() {
@@ -115,6 +115,10 @@ Formatting doesn't move the cursor.
     SomeFunction();
   }
   @end
+
+In this case the cursor is still at position (2, 5), which is no longer over the
+F in SomeFunction.
+
   :echomsg line('.') . ',' . col('.')
   ~ 2,5
 

--- a/vroom/rustfmt.vroom
+++ b/vroom/rustfmt.vroom
@@ -68,6 +68,7 @@ Errors are reported using the quickfix list.
   |  |           - ^\n
   |  |           |\n
   |  |           un-closed delimiter'
+  ~ (1 of 1): this file contains an un-closed delimiter
   fn main() {
   @end
   :echomsg line('.') . ',' . col('.')

--- a/vroom/shfmt.vroom
+++ b/vroom/shfmt.vroom
@@ -58,6 +58,7 @@ Errors are reported using the quickfix list.
   ! shfmt .*2> (.*)
   $ echo '<standard input>:1:7: reached EOF without matching { with }' >\1 (command)
   $ 1 (status)
+  ~ (1 of 1): reached EOF without matching { with }
   foo() {
   @end
   :echomsg line('.') . ',' . col('.')

--- a/vroom/zprint.vroom
+++ b/vroom/zprint.vroom
@@ -95,8 +95,9 @@ try to change directories:
   :set filetype=clojure
   :FormatCode
   ! zprint .*
+  $ no-op
   :set filetype&
-  :0file
+  :silent 0file
 
 The default setting of zprint_options propagates Vim's textwidth setting to
 zprint's command-line.


### PR DESCRIPTION
Fix some subtle issues that were being ignored by the default message strictness `GUESS-ERRORS` and explicitly capture some echo messages into vroom tests so they can pass even in STRICT mode.