### PR TITLE
js-beautify support for mustache and handlebars

### DIFF
--- a/autoload/codefmt/jsbeautify.vim
+++ b/autoload/codefmt/jsbeautify.vim
@@ -30,7 +30,8 @@ function! codefmt#jsbeautify#GetFormatter() abort
   endfunction
 
   function l:formatter.AppliesToBuffer() abort
-    return &filetype is# 'css' || &filetype is# 'html' || &filetype is# 'json' ||
+    return &filetype is# 'css' || &filetype is# 'html' ||
+        \ &filetype =~# '\mhtml\.' || &filetype is# 'json' ||
         \ &filetype is# 'javascript'
   endfunction
 
@@ -45,6 +46,8 @@ function! codefmt#jsbeautify#GetFormatter() abort
       let l:cmd = l:cmd + ['--type', 'js']
     elseif &filetype is# 'sass' || &filetype is# 'scss' || &filetype is# 'less'
       let l:cmd = l:cmd + ['--type', 'css']
+    elseif &filetype =~# '\mhtml\.'
+      let l:cmd = l:cmd + ['--type', 'html']
     elseif &filetype != ""
       let l:cmd = l:cmd + ['--type', &filetype]
     endif


### PR DESCRIPTION
The mustache/vim-mustache-handlebars plugin sets the filetype to either
html.handlebars or html.mustache. Even though js-beautify supports
formatting for these files, the `--type` parameter must be `html`.

This commit sets the `--type` parameter to `html` when the filetype
matches the regex `html\..*`.