### PR TITLE
Consolidate jsbeautify supported formats and allow for sass/scss/less

### DIFF
--- a/autoload/codefmt/jsbeautify.vim
+++ b/autoload/codefmt/jsbeautify.vim
@@ -25,14 +25,19 @@ function! codefmt#jsbeautify#GetFormatter() abort
       \ 'setup_instructions': 'Install js-beautify ' .
           \ '(https://www.npmjs.com/package/js-beautify).'}
 
-  function l:formatter.IsAvailable() abort
+  " Mapping of jsbeautify type to vim filetype name.
+  " TODO: Support jsx and other variants?
+  let l:formatter._supported_formats = {
+      \ 'js': ['javascript', 'json'],
+      \ 'css': ['css', 'sass', 'scss', 'less'],
+      \ 'html': ['html']}
+
+  function l:formatter.IsAvailable() dict abort
     return executable(s:plugin.Flag('js_beautify_executable'))
   endfunction
 
-  function l:formatter.AppliesToBuffer() abort
-    return &filetype is# 'css' || &filetype is# 'html' ||
-        \ &filetype =~# '\mhtml\.' || &filetype is# 'json' ||
-        \ &filetype is# 'javascript'
+  function l:formatter.AppliesToBuffer() dict abort
+    return self._GetSupportedFormatName(&filetype) isnot 0
   endfunction
 
   ""
@@ -40,16 +45,15 @@ function! codefmt#jsbeautify#GetFormatter() abort
   " @flag(js_beautify_executable), only targeting the range between {startline} and
   " {endline}.
   " @throws ShellError
-  function l:formatter.FormatRange(startline, endline) abort
+  function l:formatter.FormatRange(startline, endline) dict abort
     let l:cmd = [s:plugin.Flag('js_beautify_executable'), '-f', '-']
-    if &filetype is# 'javascript' || &filetype is# 'json'
-      let l:cmd = l:cmd + ['--type', 'js']
-    elseif &filetype is# 'sass' || &filetype is# 'scss' || &filetype is# 'less'
-      let l:cmd = l:cmd + ['--type', 'css']
-    elseif &filetype =~# '\mhtml\.'
-      let l:cmd = l:cmd + ['--type', 'html']
-    elseif &filetype != ""
-      let l:cmd = l:cmd + ['--type', &filetype]
+    " Add --type if known
+    if !empty(&filetype)
+      let l:format_name = self._GetSupportedFormatName(&filetype)
+      if l:format_name is 0
+        let l:format_name = &filetype
+      endif
+      let l:cmd += ['--type', l:format_name]
     endif
 
     call maktaba#ensure#IsNumber(a:startline)
@@ -59,6 +63,18 @@ function! codefmt#jsbeautify#GetFormatter() abort
     " https://github.com/beautify-web/js-beautify/issues/610
     call codefmt#formatterhelpers#AttemptFakeRangeFormatting(
         \ a:startline, a:endline, l:cmd)
+  endfunction
+
+  function l:formatter._GetSupportedFormatName(filetype) dict abort
+    " Simplify compound filetypes like "html.mustache" down to just "html".
+    " TODO: Support other compound filetypes like "javascript.*" and "css.*"?
+    let l:filetype = substitute(a:filetype, '\m^html\..*', 'html', '')
+    for [l:format_name, l:filetypes] in items(self._supported_formats)
+      if index(l:filetypes, l:filetype) >= 0
+        return l:format_name
+      endif
+    endfor
+    return 0
   endfunction
 
   return l:formatter


### PR DESCRIPTION
Deduplicates per-filetype logic in AppliesToBuffer & FormatRange to use a shared `_supported_formats` definition. In the process, updates AppliesToBuffer to accept sass/scss/less filetypes, where #114 had only fixed them to work via explicit `:FormatCode jsbeautify` but not via `:FormatCode`.

@abgeana @awused FYI