### PR TITLE
Tests: Fix several failures related to formatter precedence

### DIFF
--- a/vroom/autopep8.vroom
+++ b/vroom/autopep8.vroom
@@ -60,18 +60,6 @@ You can format any buffer with autopep8 specifying the formatter explicitly.
       pass
   @end
 
-The python filetype will use the autopep8 formatter by default.
-
-  @clear
-  % pass
-
-  :set filetype=python
-  :FormatCode
-  ! autopep8 .*
-  $ pass
-
-  :set filetype=
-
 It can format specific line ranges of code using :FormatLines.
 
   @clear

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -75,9 +75,8 @@ You can format any buffer with clang-format specifying the formatter explicitly.
   }
   @end
 
-Several filetypes will use the clang-format formatter by default: c, cpp,
-javascript, and proto.  If the version of clang-format is >= 3.6, then it will
-also format java files, but google-java-format is the default.
+Several filetypes will use the clang-format formatter by default: c, cpp, and
+proto.
 
   @clear
   % f();
@@ -88,14 +87,18 @@ also format java files, but google-java-format is the default.
   $ { "Cursor": 0 }
   $ f();
 
-  :set filetype=javascript
+  :set filetype=proto
   :FormatCode
   ! clang-format .*
   $ { "Cursor": 0 }
   $ f();
 
-  :set filetype=proto
-  :FormatCode
+It will also format javascript and java, but is not necessarily the default if
+other formatters are available.
+Note: Formatting java requires clang-format >= 3.6.
+
+  :set filetype=javascript
+  :FormatCode clang-format
   ! clang-format .*
   $ { "Cursor": 0 }
   $ f();
@@ -144,6 +147,7 @@ a string value to use everywhere...
 
   :Glaive codefmt clang_format_style='WebKit'
 
+  @clear
   % f();
   :FormatCode clang-format
   ! clang-format -style WebKit .*2>.*

--- a/vroom/jsbeautify.vroom
+++ b/vroom/jsbeautify.vroom
@@ -70,17 +70,17 @@ here we specify js-beautify explicitly.
   $ f();
 
   :set filetype=json
-  :FormatCode
+  :FormatCode js-beautify
   ! js-beautify -f - --type js 2>.*
   $ f();
 
   :set filetype=html
-  :FormatCode
+  :FormatCode js-beautify
   ! js-beautify -f - --type html 2>.*
   $ f();
 
   :set filetype=css
-  :FormatCode
+  :FormatCode js-beautify
   ! js-beautify -f - --type css 2>.*
   $ f();
 


### PR DESCRIPTION
Fixes several vroom tests that wrongly assume their formatter will be the default for a given filetype and started failing when I reordered the formatter registrations in b1b51098.

Note those precedence changes could really affect users, but only if they're relying on defaults and have multiple installed formatters for those same filetypes. If so, it's easily resolved by explicitly specifying a formatter name or uninstalling unwanted formatters.