### PR TITLE
Don't call clang-format on empty buffer

### DIFF
--- a/autoload/codefmt/clangformat.vim
+++ b/autoload/codefmt/clangformat.vim
@@ -129,6 +129,11 @@ function! codefmt#clangformat#GetFormatter() abort
   ""
   " Reformat buffer with clang-format, only targeting [ranges] if given.
   function l:formatter.FormatRanges(ranges) abort
+    if  line('$') == 1 && getline(1) == ''
+      " If the buffer is completely empty, there's nothing to do
+      return
+    endif
+
     let l:Style_value = s:plugin.Flag('clang_format_style')
     if type(l:Style_value) is# type('')
       let l:style = l:Style_value

--- a/vroom/clangformat.vroom
+++ b/vroom/clangformat.vroom
@@ -181,3 +181,10 @@ current buffer.
 
 The -assume-filename arg passed above is also related, used by the clang-format
 tool to detect any custom style rules particular to the current file.
+
+
+Bug #102. When the buffer is empty, clang-format does _not_ return a cursor
+position
+
+  @clear
+  :FormatCode clang-format


### PR DESCRIPTION
- FIXME: this test doesn't actually do anything yet
- Do not call clang-format if buffer is empty.

I did my best to generate a unit test that duplicates the bug, however I've stared
it at so long I'm going cross-eyed and I still cannot figure out a good way to do this.

My problem is I'm not sure how to check the output of `:FormatCode clang-format` for
an error (or lack thereof). I tried using a `try-catch` but was unsure how to
do this with vroom while still intercepting the system calls to provide a mocked
response.

Any help on figuring out a good unit test for this would be greatly appreciated.
