### PR TITLE
Add --lint_mode flag for buildifier

### DIFF
--- a/autoload/codefmt/buildifier.vim
+++ b/autoload/codefmt/buildifier.vim
@@ -39,7 +39,11 @@ function! codefmt#buildifier#GetFormatter() abort
   " @flag(buildifier)
   " @throws ShellError
   function l:formatter.Format() abort
+    let l:lint_flag = s:plugin.Flag('buildifier_lint_mode')
     let l:cmd = [ s:plugin.Flag('buildifier_executable') ]
+    if l:lint_flag != ""
+      let l:cmd += ["--lint=" . l:lint_flag]
+    endif
     let l:fname = expand('%:p')
     if !empty(l:fname)
       let l:cmd += ['-path', l:fname]

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -105,6 +105,14 @@ Default: 'gn' `
 The path to the buildifier executable.
 Default: 'buildifier' `
 
+                                               *codefmt:buildifier_lint_mode*
+Buildifier --lint=lint_mode parameter. Set to 'fix' to autofix issues.
+Default: '' to not pass the flag and use the buildifier default (off)
+Off:  Do not fix issues.
+Fix:  Fix issues automatically during formatting.
+Warn: Format only if there are no issues; if there are issues
+      it will cause an error and do no formatting.
+
                                               *codefmt:google_java_executable*
 The path to the google-java executable.  Generally, this should have the form:
 `java -jar /path/to/google-java`

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -101,6 +101,14 @@ call s:plugin.Flag('gn_executable', 'gn')
 call s:plugin.Flag('buildifier_executable', 'buildifier')
 
 ""
+" The lint_mode for buildifier, defaults to not passing the flag. 
+" set to 'fix' to fix issues automatically during formatting,
+" or 'off' to explicitly not fix issues (the current buildifier default).
+" Setting to 'warn' will format only if there are no issues; if there are
+" issues it will cause an error and do no formatting.
+call s:plugin.Flag('buildifier_lint_mode', '')
+
+""
 " The path to the google-java executable.  Generally, this should have the
 " form:
 " `java -jar /path/to/google-java`


### PR DESCRIPTION
In your vimrc you can do e.g.

```
call glaive#Install()
Glaive codefmt buildifier_lint_mode='fix'
```

to get buildifier to autofix issues. The default behaviour is unchanged.