### PR TITLE
Add swift autoformatting using swift-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ helpfiles in the `doc/` directory. The helpfiles are also available via
 * Shell (shfmt)
 * [Vue](http://vuejs.org) (prettier)
 * Nix (nixpkgs-fmt)
+* Swift ([swift-format](https://github.com/apple/swift-format))
 
 # Commands
 
@@ -95,6 +96,7 @@ augroup autoformat_settings
   " Alternative: autocmd FileType python AutoFormatBuffer autopep8
   autocmd FileType rust AutoFormatBuffer rustfmt
   autocmd FileType vue AutoFormatBuffer prettier
+  autocmd FileType swift AutoFormatBuffer swift-format
 augroup END
 ```
 

--- a/autoload/codefmt/swiftformat.vim
+++ b/autoload/codefmt/swiftformat.vim
@@ -1,0 +1,50 @@
+" Copyright 2022 Google Inc. All rights reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+let s:plugin = maktaba#plugin#Get('codefmt')
+
+
+""
+" @private
+" Formatter: swift-format
+function! codefmt#swiftformat#GetFormatter() abort
+  let l:formatter = {
+      \ 'name': 'swift-format',
+      \ 'setup_instructions': 'Install swift-format from ' .
+          \ '(https://github.com/apple/swift-format).'}
+
+  function l:formatter.IsAvailable() abort
+    return executable(s:plugin.Flag('swift_format_executable'))
+  endfunction
+
+  function l:formatter.AppliesToBuffer() abort
+    return &filetype is# 'swift'
+  endfunction
+
+  ""
+  " Reformat the current buffer with swift-format or the binary named in
+  " @flag(swift_format_executable)
+  "
+  " We implement Format(), and not FormatRange{,s}(), because swift-format doesn't
+  " provide a hook for formatting a range
+
+  function l:formatter.Format() abort
+    let l:executable = s:plugin.Flag('swift_format_executable')
+
+    call codefmt#formatterhelpers#Format([
+        \ l:executable])
+  endfunction
+
+  return l:formatter
+endfunction

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -48,6 +48,7 @@ The current list of defaults by filetype is:
   * python: autopep8, black, yapf
   * rust: rustfmt
   * sh: shfmt
+  * swift: swift-format
 
 ==============================================================================
 CONFIGURATION                                                 *codefmt-config*
@@ -188,6 +189,11 @@ Default: 'luaformatterfiveone' `
                                                  *codefmt:cljstyle_executable*
 The path to the cljstyle executable.
 Default: 'cljstyle' `
+
+                                                  *codefmt:swift_format_executable*
+The path to the swift-format executable.
+Default: 'swift-format' `
+
 
                                                     *codefmt:plugin[autocmds]*
 Configures whether plugin/autocmds.vim should be loaded.

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -144,6 +144,10 @@ call s:plugin.Flag('shfmt_executable', 'shfmt')
 call s:plugin.Flag('prettier_options', [])
 
 ""
+" The path to the swift-format executable.
+call s:plugin.Flag('swift_format_executable', 'swift-format')
+
+""
 " @private
 function s:LookupPrettierExecutable() abort
   return executable('npx') ? ['npx', '--no-install', 'prettier'] : 'prettier'

--- a/plugin/register.vim
+++ b/plugin/register.vim
@@ -42,6 +42,7 @@
 "   * python: autopep8, black, yapf
 "   * rust: rustfmt
 "   * sh: shfmt
+"   * swift: swift-format
 
 
 let [s:plugin, s:enter] = maktaba#plugin#Enter(expand('<sfile>:p'))
@@ -75,3 +76,4 @@ call s:registry.AddExtension(codefmt#black#GetFormatter())
 call s:registry.AddExtension(codefmt#yapf#GetFormatter())
 call s:registry.AddExtension(codefmt#rustfmt#GetFormatter())
 call s:registry.AddExtension(codefmt#shfmt#GetFormatter())
+call s:registry.AddExtension(codefmt#swiftformat#GetFormatter())

--- a/vroom/swiftformat.vroom
+++ b/vroom/swiftformat.vroom
@@ -1,0 +1,52 @@
+The built-in swift-format formatter knows how to format swift code.
+If you aren't familiar with basic codefmt usage yet, see main.vroom first.
+
+We'll set up codefmt and configure the vroom environment, then jump into some
+examples.
+
+  :source $VROOMDIR/setupvroom.vim
+
+  :let g:repeat_calls = []
+  :function FakeRepeat(...)<CR>
+  |  call add(g:repeat_calls, a:000)<CR>
+  :endfunction
+  :call maktaba#test#Override('repeat#set', 'FakeRepeat')
+
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
+
+
+The swift-format formatter expects the swift-format executable to be installed on your
+system.
+
+  % f()
+  :FormatCode swift-format
+  ! swift-format .*
+  $ f()
+
+You can format any buffer with swift-format specifying the formatter explicitly.
+
+  @clear
+  % func f(a: String,b:Int)->String{
+  | return "a" }
+  :FormatCode swift-format
+  ! swift-format .*2>.*
+  $ func f(a: String, b: Int) -> String {
+  $   return "a"
+  $ }
+  func f(a: String, b: Int) -> String {
+     return "a"
+  }
+  @end
+
+The swift filetype will use the swift-format formatter by default.
+
+  @clear
+  % f()
+
+  :set filetype=swift
+  :FormatCode
+  ! swift-format .*
+  $ f()
+
+  :set filetype=
+


### PR DESCRIPTION
This PR adds the option to autoformat swift code using Apple's [swift-format](https://github.com/apple/swift-format).

Linked issue: https://github.com/google/vim-codefmt/issues/194