### PR TITLE
Add --warnings flag for buildifier

### DIFF
--- a/autoload/codefmt/buildifier.vim
+++ b/autoload/codefmt/buildifier.vim
@@ -41,8 +41,12 @@ function! codefmt#buildifier#GetFormatter() abort
   function l:formatter.Format() abort
     let l:lint_flag = s:plugin.Flag('buildifier_lint_mode')
     let l:cmd = [ s:plugin.Flag('buildifier_executable') ]
-    if l:lint_flag != ""
+    if !empty(l:lint_flag)
       let l:cmd += ["--lint=" . l:lint_flag]
+    endif
+    let l:warnings_flag = s:plugin.Flag('buildifier_warnings')
+    if !empty(l:warnings_flag)
+      let l:cmd += ["--warnings=" . l:warnings_flag]
     endif
     let l:fname = expand('%:p')
     if !empty(l:fname)

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -117,6 +117,23 @@ Options:
   an error and do no formatting.
 Default: '' `
 
+                                                *codefmt:buildifier_warnings*
+The warnings passed to buildifier to modify the defaults. Whatever is
+specified is added to the commandline after '--warnings='. For example, if you
+add this to your config:
+
+Glaive codefmt buildifier_warnings='-module-docstring,+unsorted-dict-items'
+
+Then buildifier will omit the 'module-docstring' warning, but add 
+'unsorted-dict-items' (which is ignored by default). This works also in
+fix-mode, in which case dictionary items will be resorted upon buffer save.
+
+Options:
+"" (empty): Use default warnings from buildifier.
+"-some-warning": Remove 'some-warning' from the warning set.
+"+some-warning": Add 'some-warning' to the warning set.
+Default: ''
+
                                               *codefmt:google_java_executable*
 The path to the google-java executable.  Generally, this should have the form:
 `java -jar /path/to/google-java`

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -112,6 +112,15 @@ call s:plugin.Flag('buildifier_executable', 'buildifier')
 call s:plugin.Flag('buildifier_lint_mode', '')
 
 ""
+" The warnings for buildifier. passed to buildifier --warnings parameter.
+"
+" Options:
+"" (empty): Use default warnings from buildifier.
+"-some-warning": Remove 'some-warning' from the warning set.
+"+some-warning": Add 'some-warning' to the warning set.
+call s:plugin.Flag('buildifier_warnings', '')
+
+""
 " The path to the google-java executable.  Generally, this should have the
 " form:
 " `java -jar /path/to/google-java`


### PR DESCRIPTION
In your vimrc you can do e.g.

```
call glaive#Install()
Glaive codefmt buildifier_lint_mode='fix'
Glaive codefmt buildifier_warnings='-module-docstring,+unsorted-dict-items'
```

to get buildifier to ignore missing module docstrings but sort
dictionaries automatically. The default behaviour is unchanged.