### PR TITLE
update jsonnetfmt command

### DIFF
--- a/autoload/codefmt/jsonnetfmt.vim
+++ b/autoload/codefmt/jsonnetfmt.vim
@@ -27,7 +27,7 @@ function! codefmt#jsonnetfmt#GetFormatter() abort
     let l:cmd = [ s:plugin.Flag('jsonnetfmt_executable') ]
     let l:fname = expand('%:p')
     if !empty(l:fname)
-      let l:cmd += ['-path', l:fname]
+      let l:cmd += ['--in-place', l:fname]
     endif
 
     try


### PR DESCRIPTION
By default jsonnetfmt outputs to stdout. Use it in-place instead.