### PR TITLE
Add javascriptreact and typescriptreact to prettier files.

### DIFF
--- a/autoload/codefmt/prettier.vim
+++ b/autoload/codefmt/prettier.vim
@@ -18,7 +18,8 @@ let s:plugin = maktaba#plugin#Get('codefmt')
 " See https://prettier.io for a list of supported file types.
 if !exists('s:SUPPORTED_FILETYPES')
   let s:SUPPORTED_FILETYPES = ['javascript', 'markdown', 'html', 'css', 'yaml',
-      \ 'jsx', 'less', 'scss', 'mdx', 'vue']
+      \ 'jsx', 'less', 'scss', 'mdx', 'vue', 'javascriptreact',
+      \ 'typescriptreact']
   lockvar! s:SUPPORTED_FILETYPES
 endif
 


### PR DESCRIPTION
These were added to vim filetypes about 4 years ago (https://github.com/vim/vim/issues/4830).