### PR TITLE
Fix broken ktfmt availability check

### DIFF
--- a/autoload/codefmt/ktfmt.vim
+++ b/autoload/codefmt/ktfmt.vim
@@ -45,7 +45,7 @@ function! codefmt#ktfmt#GetFormatter() abort
         let l:success = 0
         try
           let l:result = maktaba#syscall#Create(l:cmd + ['-']).Call()
-          let l:success = v:shell_error != 0
+          let l:success = v:shell_error == 0
         catch /ERROR(ShellError)/
           call maktaba#error#Warn(
                 \ 'ktfmt unavailable, check jar file in `%s -`: %s',


### PR DESCRIPTION
(Fixes issue #218) When trying to use this locally, I was getting repeated errors that ktfmt was not available. Reversing the conditional here makes everything work correctly for me (on Linux), and also makes sense (success of a command line tool is indicated by return code equal to 0).