### PR TITLE
Fix dartfmt's IsAvailable() method.

### DIFF
--- a/autoload/codefmt/dartfmt.vim
+++ b/autoload/codefmt/dartfmt.vim
@@ -26,7 +26,13 @@ function! codefmt#dartfmt#GetFormatter() abort
           \ 'https://dart.dev/get-dart'}
 
   function l:formatter.IsAvailable() abort
-    return executable(s:plugin.Flag('dartfmt_executable'))
+    let l:cmd = codefmt#formatterhelpers#ResolveFlagToArray(
+          \ 'dartfmt_executable')
+    if !empty(l:cmd) && executable(l:cmd[0])
+      return 1
+    else
+      return 0
+    endif
   endfunction
 
   function l:formatter.AppliesToBuffer() abort
@@ -34,22 +40,14 @@ function! codefmt#dartfmt#GetFormatter() abort
   endfunction
 
   ""
-  " Reformat the current buffer with dartfmt or the binary named in
+  " Reformat the current buffer with dart format or the binary named in
   " @flag(dartfmt_executable}, only targetting the range from {startline} to
   " {endline}
   function l:formatter.FormatRange(startline, endline) abort
-    let l:dartfmt_executable = s:plugin.Flag('dartfmt_executable')
-    if type(l:dartfmt_executable) is# type([])
-      let l:cmd = l:dartfmt_executable
-    elseif type(l:dartfmt_executable) is# type('')
-      let l:cmd = [l:dartfmt_executable]
-    else
-      throw maktaba#error#WrongType(
-          \ 'dartfmt_executable flag must be a list or string. Found %s',
-          \ string(l:dartfmt_executable))
-    endif
+    let l:cmd = codefmt#formatterhelpers#ResolveFlagToArray(
+          \ 'dartfmt_executable')
     try
-      " dartfmt does not support range formatting yet:
+      " dart format does not support range formatting yet:
       " https://github.com/dart-lang/dart_style/issues/92
       call codefmt#formatterhelpers#AttemptFakeRangeFormatting(
         \ a:startline, a:endline, l:cmd)
@@ -86,4 +84,3 @@ function! codefmt#dartfmt#GetFormatter() abort
 
   return l:formatter
 endfunction
-

--- a/doc/codefmt.txt
+++ b/doc/codefmt.txt
@@ -68,7 +68,7 @@ Default: 'autopep8' `
 
                                              *codefmt:clang_format_executable*
 The path to the clang-format executable. String, list, or callable that takes
-no args and returns a string or a list.
+no args and returns a string or a list with command line arguments.
 Default: 'clang-format' `
 
                                                   *codefmt:clang_format_style*
@@ -84,7 +84,8 @@ additionally adjust imports when formatting.
 Default: 'gofmt' `
 
                                                   *codefmt:dartfmt_executable*
-The path to the dartfmt executable. Either a list or a string.
+The path to the dartfmt executable. String, list, or callable that takes no
+args and returns a string or a list with command line arguments.
 Default: ['dart', 'format'] `
 
                                               *codefmt:js_beautify_executable*
@@ -92,7 +93,8 @@ The path to the js-beautify executable.
 Default: 'js-beautify' `
 
                                                       *codefmt:mix_executable*
-The path to the mix executable for Elixir.
+The path to the mix executable for Elixir. String, list, or callable that
+takes no args and returns a string or a list with command line arguments.
 Default: 'mix' `
 
                                                      *codefmt:yapf_executable*
@@ -153,9 +155,10 @@ The path to the google-java executable.  Generally, this should have the form:
 Default: 'google-java-format' `
 
                                                     *codefmt:ktfmt_executable*
-The path to the ktfmt executable with args, as a list. The default value
-assumes there is a wrapper script named `ktfmt`. Without such a script, this
-will generally have the form:
+The path to the ktfmt executable with args. String, list, or callable that
+takes no args and returns a string or a list with command line arguments. The
+default value assumes there is a wrapper script named `ktfmt`. Without such a
+script, this will generally have the form:
 `ktfmt_executable=java,-jar,/path/to/ktfmt-VERSION-jar-with-dependencies.jar`
 
 Note that range formatting is not fully supported, with a feature request at
@@ -165,14 +168,14 @@ surrounding blocks.
 Default: ['ktfmt'] `
 
                                                        *codefmt:shfmt_options*
-Command line arguments to feed shfmt. Either a list or callable that takes no
-args and returns a list with command line arguments. By default, uses the
-Google's style. See https://github.com/mvdan/sh for details.
+Command line arguments to feed shfmt. String, list, or callable that takes no
+args and returns a string or a list with command line arguments. By default,
+uses the Google style. See https://github.com/mvdan/sh for details.
 Default: ['-i', '2', '-sr', '-ci'] `
 
                                                     *codefmt:shfmt_executable*
 The path to the shfmt executable. String, list, or callable that takes no args
-and returns a string or a list.
+and returns a string or a list with command line arguments.
 Default: 'shfmt' `
 
                                                     *codefmt:prettier_options*
@@ -190,8 +193,9 @@ Default: 'rubocop' `
 
                                                  *codefmt:prettier_executable*
 The path to the prettier executable. String, list, or callable that takes no
-args and returns a string or a list. The default uses npx if available, so
-that the repository-local prettier will have priority.
+args and returns a string or a list with command line arguments. The default
+uses npx if available, so that the repository-local prettier will have
+priority.
 Default: function('s:LookupPrettierExecutable') `
 
                                                      *codefmt:rustfmt_options*
@@ -204,9 +208,9 @@ The path to the rustfmt executable.
 Default: 'rustfmt' `
 
                                                       *codefmt:zprint_options*
-Command line arguments to feed zprint. Either a list or callable that takes no
-args and returns a list with command line arguments. The default configures
-zprint with Vim's textwidth.
+Command line arguments to feed zprint. String, list, or callable that takes no
+args and returns a string or a list with command line arguments. The default
+configures zprint with Vim's textwidth.
 Default: function('s:ZprintOptions') `
 
                                                    *codefmt:zprint_executable*

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -53,7 +53,7 @@ call s:plugin.flags.autopep8_executable.AddCallback(
 
 ""
 " The path to the clang-format executable. String, list, or callable that
-" takes no args and returns a string or a list.
+" takes no args and returns a string or a list with command line arguments.
 call s:plugin.Flag('clang_format_executable', 'clang-format')
 " Invalidate cache of detected clang-format version when this is changed,
 " regardless of {value} arg.
@@ -73,7 +73,8 @@ call s:plugin.Flag('clang_format_style', 'file')
 call s:plugin.Flag('gofmt_executable', 'gofmt')
 
 ""
-" The path to the dartfmt executable. Either a list or a string.
+" The path to the dartfmt executable. String, list, or callable that takes no
+" args and returns a string or a list with command line arguments.
 call s:plugin.Flag('dartfmt_executable', ['dart', 'format'])
 
 
@@ -82,7 +83,8 @@ call s:plugin.Flag('dartfmt_executable', ['dart', 'format'])
 call s:plugin.Flag('js_beautify_executable', 'js-beautify')
 
 ""
-" The path to the mix executable for Elixir.
+" The path to the mix executable for Elixir. String, list, or callable that
+" takes no args and returns a string or a list with command line arguments.
 call s:plugin.Flag('mix_executable', 'mix')
 
 ""
@@ -143,9 +145,10 @@ call s:plugin.Flag('jsonnetfmt_executable', 'jsonnetfmt')
 call s:plugin.Flag('google_java_executable', 'google-java-format')
 
 ""
-" The path to the ktfmt executable with args, as a list. The default value
-" assumes there is a wrapper script named `ktfmt`. Without such a script, this
-" will generally have the form:
+" The path to the ktfmt executable with args. String, list, or callable that
+" takes no args and returns a string or a list with command line arguments.
+" The default value assumes there is a wrapper script named `ktfmt`. Without
+" such a script, this will generally have the form:
 " `ktfmt_executable=java,-jar,/path/to/ktfmt-VERSION-jar-with-dependencies.jar`
 "
 " Note that range formatting is not fully supported, with a feature request at
@@ -155,15 +158,15 @@ call s:plugin.Flag('google_java_executable', 'google-java-format')
 call s:plugin.Flag('ktfmt_executable', ['ktfmt'])
 
 ""
-" Command line arguments to feed shfmt. Either a list or callable that
-" takes no args and returns a list with command line arguments. By default, uses
-" the Google's style.
+" Command line arguments to feed shfmt. String, list, or callable that
+" takes no args and returns a string or a list with command line arguments.
+" By default, uses the Google style.
 " See https://github.com/mvdan/sh for details.
 call s:plugin.Flag('shfmt_options', ['-i', '2', '-sr', '-ci'])
 
 ""
 " The path to the shfmt executable. String, list, or callable that
-" takes no args and returns a string or a list.
+" takes no args and returns a string or a list with command line arguments.
 call s:plugin.Flag('shfmt_executable', 'shfmt')
 
 ""
@@ -187,8 +190,9 @@ endfunction
 
 ""
 " The path to the prettier executable. String, list, or callable that
-" takes no args and returns a string or a list. The default uses npx if
-" available, so that the repository-local prettier will have priority.
+" takes no args and returns a string or a list with command line arguments.
+" The default uses npx if available, so that the repository-local prettier
+" will have priority.
 call s:plugin.Flag('prettier_executable', function('s:LookupPrettierExecutable'))
 
 " Invalidate cache of detected prettier availability whenever
@@ -214,9 +218,9 @@ function s:ZprintOptions() abort
 endfunction
 
 ""
-" Command line arguments to feed zprint. Either a list or callable that takes no
-" args and returns a list with command line arguments. The default configures
-" zprint with Vim's textwidth.
+" Command line arguments to feed zprint. String, list, or callable that
+" takes no args and returns a string or a list with command line arguments.
+" The default configures zprint with Vim's textwidth.
 call s:plugin.Flag('zprint_options', function('s:ZprintOptions'))
 
 ""


### PR DESCRIPTION
d927656 changed the `dartfmt_executable` flag from a string to a list, but didn't change the use inside IsAvailable(), leading to:

```
Failed to evaluate whether formatter dartfmt is available: Vim(return):E730: Using a List as a String
```

The change uses the `ResolveFlagToArray()` helper in both `IsAvailable()` and `FormatRange()` (which incidentally also allows defining the flag using a Function), and updates the documentation for all flags using `ResolveFlagToArray()` to use the same phrasing.

Fixes #190.