### PR TITLE
Remove -path from jsonnet command

### DIFF
--- a/autoload/codefmt/jsonnetfmt.vim
+++ b/autoload/codefmt/jsonnetfmt.vim
@@ -30,7 +30,7 @@ function! codefmt#jsonnetfmt#GetFormatter() abort
     let l:cmd = [ s:plugin.Flag('jsonnetfmt_executable') ]
     let l:fname = expand('%:p')
     if !empty(l:fname)
-      let l:cmd += ['-path', l:fname]
+      let l:cmd += [l:fname]
     endif
 
     try


### PR DESCRIPTION
The jsonnetfmt help text does not mention a path argument and when running `:FormatCode` in a jsonnet file I get an error saying that -p is an unrecognized argument. But removing `-path` in my local copy of the plugin allows vim to reform my jsonnet files.

```
jsonnetfmt --help
Jsonnet reformatter v0.17.0

jsonnetfmt {<option>} { <filename> }

Available options:
  -h / --help             This message
  -e / --exec             Treat filename as code
  -o / --output-file <file> Write to the output file rather than stdout
  -i / --in-place         Update the Jsonnet file(s) in place.
  --test                  Exit with failure if reformatting changed the file(s).
  -n / --indent <n>       Number of spaces to indent by (default 2, 0 means no change)
  --max-blank-lines <n>   Max vertical spacing, 0 means no change (default 2)
  --string-style <d|s|l>  Enforce double, single (default) quotes or 'leave'
  --comment-style <h|s|l> # (h), // (s)(default), or 'leave'; never changes she-bang
  --[no-]pretty-field-names Use syntax sugar for fields and indexing (on by default)
  --[no-]pad-arrays       [ 1, 2, 3 ] instead of [1, 2, 3]
  --[no-]pad-objects      { x: 1, y: 2 } instead of {x: 1, y: 2} (on by default)
  --[no-]sort-imports     Sorting of imports (on by default)
  --debug-desugaring      Unparse the desugared AST without executing it
  --version               Print version

In all cases:
<filename> can be - (stdin)
Multichar options are expanded e.g. -abc becomes -a -b -c.
The -- option suppresses option processing for subsequent arguments.
Note that since filenames and jsonnet programs can begin with -, it is advised to
use -- if the argument is unknown, e.g. jsonnet -- "$FILENAME".
```

The history of the jsonnetfmt file has not changed in many years so I don't think this is a recent change either.
https://github.com/google/jsonnet/commits/e605e4673294d2bf43eb8351fb8f5d9ba26d5e68/cmd/jsonnetfmt.cpp