### PR TITLE
add lua formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ codefmt` if codefmt is installed (and helptags have been generated).
 *   Julia ([JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl))
 *   Kotlin ([ktfmt](https://github.com/facebookincubator/ktfmt))
 *   Lua
-    ([FormatterFiveOne](https://luarocks.org/modules/ElPiloto/formatterfiveone)
+    ([FormatterFiveOne](https://luarocks.org/modules/ElPiloto/formatterfiveone),
+    [StyLua](https://github.com/JohnnyMorganz/StyLua))
 *   Markdown (prettier)
 *   Nix (nixpkgs-fmt)
 *   OCaml ([ocamlformat](https://github.com/ocaml-ppx/ocamlformat))

--- a/autoload/codefmt/stylua.vim
+++ b/autoload/codefmt/stylua.vim
@@ -1,0 +1,57 @@
+let s:plugin = maktaba#plugin#Get('codefmt')
+
+
+""
+" @private
+"
+" Formatter provider for lua files using stylua.
+function! codefmt#stylua#GetFormatter() abort
+  let l:formatter = {
+      \ 'name': 'stylua',
+      \ 'setup_instructions': 'Install stylua (https://github.com/JohnnyMorganz/StyLua).'}
+
+  function l:formatter.IsAvailable() abort
+    return executable(s:plugin.Flag('stylua_executable'))
+  endfunction
+
+  function l:formatter.AppliesToBuffer() abort
+    return codefmt#formatterhelpers#FiletypeMatches(&filetype, 'lua')
+  endfunction
+
+  ""
+  " Reformat the current buffer with stylua or the binary named in
+  " @flag(stylua_executable)
+  " @throws ShellError
+  function l:formatter.Format() abort
+    let l:cmd = [s:plugin.Flag('stylua_executable')]
+    " Specify we are sending input through stdin
+    let l:cmd += ['--stdin-filepath', expand('%:p'), '-']
+
+    try
+      call codefmt#formatterhelpers#Format(l:cmd)
+    catch
+      " Parse all the errors and stick them in the quickfix list.
+      let l:errors = []
+      for line in split(v:exception, "\n")
+        let l:fname_pattern = 'stdin'
+        let l:tokens = matchlist(line, '\C\v^\[string "isCodeValid"\]:(\d+): (.*)')
+        if !empty(l:tokens)
+          call add(l:errors, {
+              \ "filename": @%,
+              \ "lnum": l:tokens[1],
+              \ "text": l:tokens[2]})
+        endif
+      endfor
+
+      if empty(l:errors)
+        " Couldn't parse stylua error format; display it all.
+        call maktaba#error#Shout('Error formatting file: %s', v:exception)
+      else
+        call setqflist(l:errors, 'r')
+        cc 1
+      endif
+    endtry
+  endfunction
+
+  return l:formatter
+endfunction

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -246,6 +246,11 @@ call s:plugin.Flag('nixpkgs_fmt_executable', 'nixpkgs-fmt')
 ""
 " The path to the luaformatterfiveone executable.
 call s:plugin.Flag('luaformatterfiveone_executable', 'luaformatterfiveone')
+"
+""
+" The path to the stylua executable.
+call s:plugin.Flag('stylua_executable', 'stylua')
+
 
 ""
 " The path to the cljstyle executable.

--- a/plugin/register.vim
+++ b/plugin/register.vim
@@ -41,7 +41,7 @@
 "   * json, jsonnet: jsonnetfmt
 "   * julia: JuliaFormatter
 "   * kotlin: ktfmt
-"   * lua: luaformatterfiveone
+"   * lua: luaformatterfiveone, stylua
 "   * nix: nixpkgs-fmt
 "   * ocaml: ocamlformat
 "   * python: autopep8, black, yapf
@@ -78,6 +78,7 @@ call s:registry.AddExtension(codefmt#prettier#GetFormatter())
 call s:registry.AddExtension(codefmt#juliaformatter#GetFormatter())
 call s:registry.AddExtension(codefmt#ktfmt#GetFormatter())
 call s:registry.AddExtension(codefmt#luaformatterfiveone#GetFormatter())
+call s:registry.AddExtension(codefmt#stylua#GetFormatter())
 call s:registry.AddExtension(codefmt#nixpkgs_fmt#GetFormatter())
 call s:registry.AddExtension(codefmt#autopep8#GetFormatter())
 call s:registry.AddExtension(codefmt#isort#GetFormatter())

--- a/vroom/stylua.vroom
+++ b/vroom/stylua.vroom
@@ -1,0 +1,55 @@
+stylua is a formatter that knows how to format all lua code
+If you aren't familiar with basic codefmt usage yet, see main.vroom
+
+We'll set up codefmt and configure the vroom environment, then jump into some
+examples.
+
+  :source $VROOMDIR/setupvroom.vim
+
+  :let g:repeat_calls = []
+  :function FakeRepeat(...)<CR>
+  |  call add(g:repeat_calls, a:000)<CR>
+  :endfunction
+  :call maktaba#test#Override('repeat#set', 'FakeRepeat')
+
+  :call codefmt#SetWhetherToPerformIsAvailableChecksForTesting(0)
+
+
+stylua expects the executable to be installed on your system.
+
+  % function hello()<CR>
+  % print("world")<CR>
+  % end
+  :FormatCode stylua
+  ! stylua -i 2> .*
+  $ function hello()
+  $   print("world")
+  $ end
+
+The name or path of the stylua executable can be configured via the
+stylua_executable flag if the default of "buildifier" doesn't work.
+
+  :Glaive codefmt stylua_executable='mystylua'
+  :FormatCode stylua
+  ! mystylelua -i 2> .*
+  $ function hello()
+  $   print("world")
+  $ end
+  :Glaive codefmt stylua_executable='stylua'
+
+Errors are reported using the quickfix list.
+
+  @clear
+  % 13()
+  :FormatCode stylua
+  ! stylua -i 2> (.*)
+  $ 1 (status)
+  $ echo >\1 ' (command)
+  |stylua:Unable to format stdin:\n
+  |[string "isCodeValid"]:1: unexpected symbol near '"'13'"
+  ~ (1 of 1): unexpected symbol near '13'
+  :echomsg line('.') . ',' . col('.')
+  ~ 1,1
+  :echomsg string(map(getqflist(), 'v:val.lnum . "," . v:val.text'))
+  ~ ['1,unexpected symbol near ''13''']
+


### PR DESCRIPTION
This PR adds [`stylua`](https://github.com/JohnnyMorganz/StyLua) as an alternative formatter for Lua. 
 - [x] adds `Stylua` to README, corrects missing `)`
 - [x] find/replace `formatterfiveone` with `stylua`
 - [ ] `vroom` has been [archived](https://github.com/google/vroom) and was unable to get it to build on an M3 MBP but took inspiration from `black.vroom`, should work? I could use some help testing this

Partially addresses #180.