### PR TITLE
ruff formatter: Fix bug running non-stdin version

### DIFF
--- a/autoload/codefmt/ruff.vim
+++ b/autoload/codefmt/ruff.vim
@@ -19,7 +19,7 @@ let s:plugin = maktaba#plugin#Get('codefmt')
 function! s:FormatWithArgs(args) abort
   let l:executable = s:plugin.Flag('ruff_executable')
   let l:lines = getline(1, line('$'))
-  let l:cmd = [l:executable, 'format'] + a:args
+  let l:cmd = [l:executable, 'format'] + a:args + ['-']
   if !empty(@%)
     let l:cmd += ['--stdin-filename=' . @%]
   endif

--- a/vroom/ruff.vroom
+++ b/vroom/ruff.vroom
@@ -21,7 +21,7 @@ system.
   :silent file somefile.py
   % f()
   :FormatCode ruff
-  ! ruff format --stdin-filename=somefile.py.*
+  ! ruff format - --stdin-filename=somefile.py.*
   $ f()
 
 The name or path of the ruff executable can be configured via the
@@ -29,7 +29,7 @@ ruff_executable flag if the default of "ruff" doesn't work.
 
   :Glaive codefmt ruff_executable='/somepath/ruff'
   :FormatCode ruff
-  ! /somepath/ruff format.*
+  ! /somepath/ruff format -.*
   $ f()
   :Glaive codefmt ruff_executable='ruff'
 
@@ -40,7 +40,7 @@ You can format any buffer with ruff specifying the formatter explicitly.
   % if True: pass
 
   :FormatCode ruff
-  ! ruff format.*
+  ! ruff format -.*
   $ if True:
   $     pass
   if True:
@@ -55,7 +55,7 @@ It can format specific line ranges of code using :FormatLines.
   |else: bar-=1;
 
   :2,3FormatLines ruff
-  ! ruff format .*--range=2:3.*
+  ! ruff format .*--range=2:3 -.*
   $ some_tuple=(   1,2, 3,'a'  );
   $ if bar:
   $     bar += 1


### PR DESCRIPTION
Forgot to pass the "-" placeholder for stdin. Apparently if you pass --stdin-filename ruff assumes stdin, but if there's no filename it can get confused and format everything in-place instead of formatting the editor buffer.

Fixes #223 (properly).